### PR TITLE
Deepen reminder lifecycle ownership

### DIFF
--- a/src/bot_runtime.py
+++ b/src/bot_runtime.py
@@ -25,7 +25,6 @@ from bot_state import (
 from discord_messages import send_command_response
 from models import CommandParameters
 from reminders import Reminders
-from reminders.constants import MIN_REMIND_ARGUMENTS
 from tags import Tags
 
 CommandHandler = Callable[[CommandParameters], Awaitable[str]]
@@ -293,19 +292,7 @@ class BotRuntime:
         reminder_handler = self._reminders.get(guild_id)
         if reminder_handler is None:
             return ""
-        command_message = parameters.message
-        time = command_message[0] if command_message else "help"
-        message = command_message[1:]
-        if len(command_message) < MIN_REMIND_ARGUMENTS:
-            time = "help"
-        return await reminder_handler.create_reminder(
-            time,
-            message,
-            parameters.author_id,
-            guild_id,
-            channel_id,
-            user_name=parameters.author_name,
-        )
+        return await reminder_handler.handle(parameters)
 
     async def _mock(self, parameters: CommandParameters) -> str:
         """Return the command message in alternating case."""

--- a/src/reminders/reminders.py
+++ b/src/reminders/reminders.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
 import discord
@@ -21,16 +24,37 @@ from .constants import (
     HUMAN_DATE_FORMAT,
     MAX_REMINDER_SECONDS,
     MAX_REMINDERS_PER_GUILD,
+    MIN_REMIND_ARGUMENTS,
     REMINDER_DELIVERY_ATTEMPTS,
     REMINDER_DELIVERY_RETRY_DELAY_SECONDS,
 )
 from .models import DatetimePassedResult, ReminderFile, ReminderRecord
 
+if TYPE_CHECKING:
+    from models import CommandParameters
+
 _logger = logging.getLogger(__name__)
 DISPLAY_TIMEZONE = ZoneInfo("America/New_York")
 
+Now = Callable[[], datetime]
+Sleep = Callable[[float], Awaitable[None]]
+ReminderSender = Callable[[discord.abc.Messageable, int, str], Awaitable[None]]
 
-def parse_time(time: str) -> int | None:
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+@dataclass(frozen=True, slots=True)
+class _ReminderDependencies:
+    """Private clock, delay, and delivery adapters for reminder tests."""
+
+    now: Now = _utc_now
+    sleep: Sleep = asyncio.sleep
+    send_reminder: ReminderSender = send_reminder_response
+
+
+def _parse_time(time: str) -> int | None:
     """Convert a compact duration string into seconds."""
     if not time:
         return None
@@ -49,16 +73,15 @@ def parse_time(time: str) -> int | None:
     return amount * multiplier
 
 
-def add_time_to_date(date: datetime | str, seconds: int) -> datetime:
+def _add_time_to_date(date: datetime | str, seconds: int) -> datetime:
     """Add seconds to a UTC datetime or serialized datetime string."""
     if isinstance(date, str):
         date = datetime.strptime(date, DATE_FORMAT).replace(tzinfo=UTC)
     return date + timedelta(seconds=seconds)
 
 
-def has_datetime_passed(planned_execution_date: datetime | str) -> DatetimePassedResult:
+def _has_datetime_passed(planned_execution_date: datetime | str, current_datetime: datetime) -> DatetimePassedResult:
     """Report whether a planned UTC execution datetime has passed."""
-    current_datetime = datetime.now(UTC)
     if isinstance(planned_execution_date, str):
         planned_execution_date = datetime.strptime(planned_execution_date, DATE_FORMAT).replace(tzinfo=UTC)
     _logger.info(
@@ -87,9 +110,9 @@ def has_datetime_passed(planned_execution_date: datetime | str) -> DatetimePasse
     return DatetimePassedResult(result=True, seconds_until_execution=-1)
 
 
-def parse_reminder_delay(seconds: str) -> tuple[int | None, str | None]:
+def _parse_reminder_delay(seconds: str) -> tuple[int | None, str | None]:
     """Return a valid reminder delay or the user-facing validation error."""
-    delay_seconds = parse_time(seconds)
+    delay_seconds = _parse_time(seconds)
     if delay_seconds is None:
         return None, "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"
     if delay_seconds > MAX_REMINDER_SECONDS:
@@ -102,75 +125,83 @@ def parse_reminder_delay(seconds: str) -> tuple[int | None, str | None]:
 class Reminders:
     """Manage persisted reminders and scheduled reminder messages for a guild."""
 
-    def __init__(self, guild: discord.Guild, reminders_json_path: str | Path) -> None:
+    def __init__(
+        self,
+        guild: discord.Guild,
+        reminders_json_path: str | Path,
+        *,
+        _dependencies: _ReminderDependencies | None = None,
+    ) -> None:
         """Initialize paths and default reminder state for a guild."""
-        self.guild = guild
-        self.reminders_json_path = Path(reminders_json_path)
-        self.reminders_json_file = self.reminders_json_path / f"{guild.id}.json"
-        self.reminders = ReminderFile(name=guild.name, id=guild.id)
+        self._dependencies = replace(_dependencies) if _dependencies is not None else _ReminderDependencies()
+        self._guild = guild
+        self._reminders_json_path = Path(reminders_json_path)
+        self._reminders_json_file = self._reminders_json_path / f"{guild.id}.json"
+        self._reminders = ReminderFile(name=guild.name, id=guild.id)
         self._timer_tasks: set[asyncio.Task[None]] = set()
         self._reminder_lock = asyncio.Lock()
 
     @classmethod
-    async def create(cls, guild: discord.Guild, reminders_json_path: str | Path) -> Reminders:
+    async def create(
+        cls,
+        guild: discord.Guild,
+        reminders_json_path: str | Path,
+        *,
+        _dependencies: _ReminderDependencies | None = None,
+    ) -> Reminders:
         """Create a reminder handler and schedule any pending reminders."""
-        reminder_handler = cls(guild, reminders_json_path)
-        reminder_handler.reminders = await reminder_handler.load_reminders()
-        await reminder_handler.clean_reminders()
-        await reminder_handler.parse_reminders()
+        reminder_handler = cls(guild, reminders_json_path, _dependencies=_dependencies)
+        reminder_handler._reminders = await reminder_handler._load_reminders()
+        await reminder_handler._clean_reminders()
+        await reminder_handler._parse_reminders()
         return reminder_handler
 
-    async def create_json(self) -> None:
+    async def _create_json(self) -> None:
         """Create the reminders directory and guild JSON file when missing."""
 
         def create_json_sync() -> None:
-            self.reminders_json_path.mkdir(parents=True, exist_ok=True)
-            create_json = ReminderFile(name=self.guild.name, id=self.guild.id)
+            self._reminders_json_path.mkdir(parents=True, exist_ok=True)
+            initial_state = ReminderFile(name=self._guild.name, id=self._guild.id)
             try:
-                with self.reminders_json_file.open("x", encoding="utf-8") as reminders_file:
-                    json.dump(create_json.model_dump(mode="json"), reminders_file)
+                with self._reminders_json_file.open("x", encoding="utf-8") as reminders_file:
+                    json.dump(initial_state.model_dump(mode="json"), reminders_file)
             except FileExistsError:
                 return
-            _logger.info("%s: created: %s", self.guild.name, self.reminders_json_file)
+            _logger.info("%s: created: %s", self._guild.name, self._reminders_json_file)
 
         await asyncio.to_thread(create_json_sync)
 
-    async def load_reminders(self) -> ReminderFile:
+    async def _load_reminders(self) -> ReminderFile:
         """Return the guild's reminders JSON data."""
-        await self.create_json()
-        _logger.info("%s: loading: %s", self.guild.name, self.reminders_json_file)
-        with self.reminders_json_file.open(encoding="utf-8") as reminders:
+        await self._create_json()
+        _logger.info("%s: loading: %s", self._guild.name, self._reminders_json_file)
+        with self._reminders_json_file.open(encoding="utf-8") as reminders:
             return ReminderFile.model_validate(json.load(reminders))
-
-    async def save_reminders(self) -> None:
-        """Write the guild's reminders to disk."""
-        async with self._reminder_lock:
-            await self._save_reminders_unlocked()
 
     async def _save_reminders_unlocked(self) -> None:
         """Write reminders to disk while the caller holds the reminder lock."""
-        _logger.info("%s: saving: %s", self.guild.name, self.reminders_json_file)
-        with atomic_write(self.reminders_json_file, overwrite=True, encoding="utf-8") as reminders_file:
-            reminders_file.write(json.dumps(self.reminders.model_dump(mode="json"), sort_keys=True, indent=2))
+        _logger.info("%s: saving: %s", self._guild.name, self._reminders_json_file)
+        with atomic_write(self._reminders_json_file, overwrite=True, encoding="utf-8") as reminders_file:
+            reminders_file.write(json.dumps(self._reminders.model_dump(mode="json"), sort_keys=True, indent=2))
 
-    async def clean_reminders(self) -> None:
+    async def _clean_reminders(self) -> None:
         """Remove expired reminders and persist the cleaned reminder list."""
-        _logger.info("%s: cleaning: %s", self.guild.name, self.reminders_json_file)
+        _logger.info("%s: cleaning: %s", self._guild.name, self._reminders_json_file)
         async with self._reminder_lock:
             active_reminders = [
                 reminder
-                for reminder in self.reminders.reminders
-                if not has_datetime_passed(reminder.execution_time).result
+                for reminder in self._reminders.reminders
+                if not _has_datetime_passed(reminder.execution_time, self._dependencies.now()).result
             ]
-            if len(active_reminders) != len(self.reminders.reminders):
-                self.reminders.reminders = active_reminders
+            if len(active_reminders) != len(self._reminders.reminders):
+                self._reminders.reminders = active_reminders
                 await self._save_reminders_unlocked()
 
-    async def list_reminders(self) -> str:
+    async def _list_reminders(self) -> str:
         """Return a formatted list of active reminders."""
-        await self.clean_reminders()
+        await self._clean_reminders()
         async with self._reminder_lock:
-            reminders = list(self.reminders.reminders)
+            reminders = list(self._reminders.reminders)
         messages: list[str] = []
         for reminder in reminders:
             reminder_date = datetime.strptime(reminder.execution_time, DATE_FORMAT).replace(tzinfo=UTC)
@@ -182,41 +213,41 @@ class Reminders:
             return "No active reminds were found"
         return truncate_discord_message("".join(messages))
 
-    async def parse_reminders(self) -> None:
+    async def _parse_reminders(self) -> None:
         """Schedule all currently persisted reminders."""
-        _logger.info("%s: parse_reminders()", self.guild.name)
-        _logger.info("%s: %s", self.guild.name, self.reminders)
+        _logger.info("%s: parse_reminders()", self._guild.name)
+        _logger.info("%s: %s", self._guild.name, self._reminders)
         async with self._reminder_lock:
-            reminders = list(self.reminders.reminders)
+            reminders = list(self._reminders.reminders)
         for reminder in reminders:
-            await self.parse_reminder(reminder)
+            await self._parse_reminder(reminder)
 
-    async def parse_reminder(self, reminder: ReminderRecord) -> None:
+    async def _parse_reminder(self, reminder: ReminderRecord) -> None:
         """Schedule a reminder if it has not already expired."""
-        _logger.info("%s: parse_reminder()", self.guild.name)
-        passed_result = has_datetime_passed(reminder.execution_time)
+        _logger.info("%s: parse_reminder()", self._guild.name)
+        passed_result = _has_datetime_passed(reminder.execution_time, self._dependencies.now())
         if not passed_result.result:
-            self.create_timer(reminder, passed_result.seconds_until_execution)
+            self._create_timer(reminder, passed_result.seconds_until_execution)
         else:
             _logger.info(
                 "%s: parse_reminder() - reminder for %s that says %s alredy expired",
-                self.guild.name,
+                self._guild.name,
                 reminder.name,
                 reminder.message,
             )
 
-    def create_timer(
+    def _create_timer(
         self,
         reminder: ReminderRecord,
         delay_seconds: float,
     ) -> None:
         """Create an async timer that sends a reminder message later."""
-        task = asyncio.create_task(self.send_message(reminder, delay_seconds))
+        task = asyncio.create_task(self._send_message(reminder, delay_seconds))
         self._timer_tasks.add(task)
         task.add_done_callback(self._timer_finished)
         _logger.info(
             "%s: created timer for %s that will execute in %s seconds",
-            self.guild.name,
+            self._guild.name,
             reminder.name,
             delay_seconds,
         )
@@ -228,7 +259,7 @@ class Reminders:
             return
         exception = task.exception()
         if exception is not None:
-            _logger.error("%s: reminder timer failed", self.guild.name, exc_info=exception)
+            _logger.error("%s: reminder timer failed", self._guild.name, exc_info=exception)
 
     async def close(self) -> None:
         """Cancel and await all scheduled timers owned by this guild handler."""
@@ -238,41 +269,41 @@ class Reminders:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
 
-    async def remove_reminder(self, reminder: ReminderRecord) -> None:
+    async def _remove_reminder(self, reminder: ReminderRecord) -> None:
         """Remove a completed reminder from memory and disk."""
         async with self._reminder_lock:
             try:
-                self.reminders.reminders.remove(reminder)
+                self._reminders.reminders.remove(reminder)
             except ValueError:
-                _logger.info("%s: reminder was already removed: %s", self.guild.name, reminder)
+                _logger.info("%s: reminder was already removed: %s", self._guild.name, reminder)
                 return
             await self._save_reminders_unlocked()
 
-    async def send_message(self, reminder: ReminderRecord, seconds: float) -> None:
+    async def _send_message(self, reminder: ReminderRecord, seconds: float) -> None:
         """Wait for the requested delay, then send the reminder to a channel."""
-        await asyncio.sleep(seconds)
+        await self._dependencies.sleep(seconds)
         for attempt in range(1, REMINDER_DELIVERY_ATTEMPTS + 1):
             if await self._try_send_reminder(reminder, attempt):
-                await self.remove_reminder(reminder)
+                await self._remove_reminder(reminder)
                 return
             if attempt < REMINDER_DELIVERY_ATTEMPTS:
-                await asyncio.sleep(REMINDER_DELIVERY_RETRY_DELAY_SECONDS)
+                await self._dependencies.sleep(REMINDER_DELIVERY_RETRY_DELAY_SECONDS)
 
         _logger.error(
             "%s: failed to send reminder after %s attempts: %s",
-            self.guild.name,
+            self._guild.name,
             REMINDER_DELIVERY_ATTEMPTS,
             reminder,
         )
-        await self.remove_reminder(reminder)
+        await self._remove_reminder(reminder)
 
     async def _try_send_reminder(self, reminder: ReminderRecord, attempt: int) -> bool:
         """Try to send a reminder once."""
-        channel = self.guild.get_channel(reminder.channel_id)
+        channel = self._guild.get_channel(reminder.channel_id)
         if channel is None:
             _logger.warning(
                 "%s: channel %s was not found for reminder send attempt %s",
-                self.guild.name,
+                self._guild.name,
                 reminder.channel_id,
                 attempt,
             )
@@ -280,33 +311,30 @@ class Reminders:
         if not isinstance(channel, discord.abc.Messageable):
             _logger.warning(
                 "%s: channel %s cannot receive reminder messages on attempt %s",
-                self.guild.name,
+                self._guild.name,
                 reminder.channel_id,
                 attempt,
             )
             return False
         try:
-            await send_reminder_response(channel, reminder.user_id, reminder.message)
+            await self._dependencies.send_reminder(channel, reminder.user_id, reminder.message)
         except discord.HTTPException:
             _logger.exception(
                 "%s: failed to send reminder to channel %s on attempt %s",
-                self.guild.name,
+                self._guild.name,
                 reminder.channel_id,
                 attempt,
             )
             return False
         return True
 
-    async def create_reminder(
-        self,
-        seconds: str,
-        message: list[str],
-        user_id: int,
-        guild_id: int,
-        channel_id: int,
-        user_name: str | None = None,
-    ) -> str:
-        """Create, persist, and schedule a reminder from a user command."""
+    async def handle(self, parameters: CommandParameters) -> str:
+        """Interpret a command and own validation, persistence, and scheduling."""
+        command_message = parameters.message
+        seconds = command_message[0] if command_message else "help"
+        message = command_message[1:]
+        if len(command_message) < MIN_REMIND_ARGUMENTS:
+            seconds = "help"
         match seconds:
             case "help":
                 return (
@@ -314,39 +342,39 @@ class Reminders:
                     "s (seconds), m (minutes), h (hours), or d (days)."
                 )
             case "list":
-                return await self.list_reminders()
+                return await self._list_reminders()
             case _:
-                delay_seconds, error_message = parse_reminder_delay(seconds)
+                delay_seconds, error_message = _parse_reminder_delay(seconds)
         if delay_seconds is None:
             if error_message is None:
                 msg = "reminder delay validation failed without an error message"
                 raise ValueError(msg)
             return error_message
         reminder_message = truncate_text(" ".join(message), DISCORD_MESSAGE_LIMIT)
-        created_at = datetime.now(UTC)
-        reminder_user_name = user_name or str(user_id)
+        created_at = self._dependencies.now()
+        reminder_user_name = parameters.author_name or str(parameters.author_id)
         reminder = ReminderRecord(
-            user_id=user_id,
+            user_id=parameters.author_id,
             name=reminder_user_name,
             message=reminder_message,
             created_at=created_at.strftime(DATE_FORMAT),
-            execution_time=add_time_to_date(created_at, delay_seconds).strftime(DATE_FORMAT),
+            execution_time=_add_time_to_date(created_at, delay_seconds).strftime(DATE_FORMAT),
             timezone="utc",
-            guild_id=guild_id,
-            channel_id=channel_id,
+            guild_id=parameters.guild_id if parameters.guild_id is not None else self._guild.id,
+            channel_id=parameters.channel_id,
         )
         async with self._reminder_lock:
-            if len(self.reminders.reminders) >= MAX_REMINDERS_PER_GUILD:
+            if len(self._reminders.reminders) >= MAX_REMINDERS_PER_GUILD:
                 return (
                     "Reminder limit reached. Delete or wait for a reminder to complete before creating a new one. "
                     f"Limit: {MAX_REMINDERS_PER_GUILD}"
                 )
-            self.reminders.reminders.append(reminder)
+            self._reminders.reminders.append(reminder)
             await self._save_reminders_unlocked()
         execution_time = (
             (created_at + timedelta(seconds=delay_seconds)).astimezone(DISPLAY_TIMEZONE).strftime(HUMAN_DATE_FORMAT)
         )
-        self.create_timer(reminder, delay_seconds)
+        self._create_timer(reminder, delay_seconds)
         return truncate_discord_message(
             f"Created reminder for {reminder_user_name} to go off at {execution_time} that says `{reminder_message}`"
         )

--- a/tests/test_bot_runtime.py
+++ b/tests/test_bot_runtime.py
@@ -15,12 +15,11 @@ import pytest
 
 from bot_runtime import GENERIC_COMMAND_ERROR, BotRuntime, _RuntimeDependencies
 from bot_state import DATA_DIR_ENV_VAR
+from models import CommandParameters
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from pathlib import Path
-
-    from models import CommandParameters
 
 
 def run[T](coro: Coroutine[object, object, T]) -> T:
@@ -65,15 +64,15 @@ class RecordingReminder:
     def __init__(self, *, close_error: Exception | None = None) -> None:
         self.close_error = close_error
         self.closed = False
-        self.create_calls: list[tuple[object, ...]] = []
+        self.parameters: list[CommandParameters] = []
 
     async def close(self) -> None:
         self.closed = True
         if self.close_error is not None:
             raise self.close_error
 
-    async def create_reminder(self, *args: object, **kwargs: object) -> str:
-        self.create_calls.append((*args, kwargs))
+    async def handle(self, parameters: CommandParameters) -> str:
+        self.parameters.append(parameters)
         return "reminder response"
 
 
@@ -506,17 +505,26 @@ def test_tag_command_parameters_preserve_message_context_and_attachment(tmp_path
     assert parameters.fetch_user_func is None
 
 
-def test_reminder_command_routes_to_initialized_guild_handler(tmp_path: Path) -> None:
+@pytest.mark.parametrize("arguments", ["5m drink water", "", "list", "help ignored", "bad duration"])
+def test_reminder_command_routes_to_initialized_guild_handler(tmp_path: Path, arguments: str) -> None:
     guild = make_guild(910)
     runtime, _client, factories = make_runtime(tmp_path, client=FakeClient(guilds=[guild]))
     channel = RecordingChannel()
     run(runtime.on_ready())
 
-    run(runtime.on_message(make_message("$remind 5m drink water", guild=guild, channel=channel)))
+    run(runtime.on_message(make_message(f"$remind {arguments}", guild=guild, channel=channel)))
 
     assert sent_text(channel) == ["reminder response"]
-    assert factories.reminders[guild.id].create_calls == [
-        ("5m", ["drink", "water"], 123, 910, 789, {"user_name": "Alice"})
+    assert factories.reminders[guild.id].parameters == [
+        CommandParameters(
+            command="remind",
+            message=arguments.split(),
+            created_at=datetime(2026, 6, 4, tzinfo=UTC),
+            author_id=123,
+            author_name="Alice",
+            guild_id=910,
+            channel_id=789,
+        )
     ]
 
 
@@ -678,3 +686,57 @@ def test_malformed_guild_registry_file_is_retained_while_other_registry_initiali
     assert bad_file.read_text(encoding="utf-8") == "{bad json"
     other_file = tmp_path / ("reminders" if bad_registry == "tags" else "tags") / f"{guild.id}.json"
     assert other_file.exists()
+
+
+@pytest.mark.parametrize("command", ["remind", "tag"])
+def test_guild_commands_preserve_missing_guild_response(tmp_path: Path, command: str) -> None:
+    runtime, _client, _factories = make_runtime(tmp_path)
+    channel = RecordingChannel()
+    message = make_message(f"${command}", channel=channel)
+    message.guild = None
+    run(runtime.on_message(message))
+    expected = (
+        "guild_id (None) or channel_id 789 is None." if command == "remind" else "unable to get tag. guild_id is None"
+    )
+    assert sent_text(channel) == [expected]
+
+
+def test_missing_reminder_handler_keeps_empty_response(tmp_path: Path) -> None:
+    runtime, _client, _factories = make_runtime(tmp_path)
+    channel = RecordingChannel()
+    run(runtime.on_message(make_message("$remind 5m stretch", channel=channel)))
+    assert sent_text(channel) == [""]
+
+
+def test_guild_removal_discards_both_registries_before_awaiting_shutdown(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        class WaitingReminder(RecordingReminder):
+            async def close(self) -> None:
+                entered.set()
+                await release.wait()
+
+        async def make_reminder(_guild: object, _path: Path) -> WaitingReminder:
+            return WaitingReminder()
+
+        guild = make_guild()
+        factories = RecordingFactories()
+        runtime = BotRuntime(
+            FakeClient(guilds=[guild]),
+            command_delimiter="$",
+            data_dir=tmp_path,
+            _dependencies=_RuntimeDependencies(tag_factory=factories.make_tag, reminder_factory=make_reminder),
+        )
+        await runtime.on_ready()
+        removal = asyncio.create_task(runtime.on_guild_remove(guild))
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        channel = RecordingChannel()
+        await runtime.on_message(make_message("$tag launch", channel=channel))
+        await runtime.on_message(make_message("$remind 5m stretch", channel=channel))
+        assert sent_text(channel) == ["unable to get tag. tag function parameter is None", ""]
+        release.set()
+        await removal
+
+    run(exercise())

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1,47 +1,95 @@
-"""Tests for reminder parsing and creation behavior."""
+"""Reminder behavior through construction, commands, delivery adapters, and shutdown."""
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import discord
 import pytest
+from pydantic import ValidationError
 
 from message_limits import DISCORD_MESSAGE_LIMIT, TRUNCATION_SUFFIX
-from reminders.constants import (
-    DATE_FORMAT,
-    MAX_REMINDER_SECONDS,
-    MAX_REMINDERS_PER_GUILD,
-    REMINDER_DELIVERY_ATTEMPTS,
-    REMINDER_DELIVERY_RETRY_DELAY_SECONDS,
-)
-from reminders.models import ReminderRecord
-from reminders.reminders import Reminders, add_time_to_date, has_datetime_passed, parse_time
+from models import CommandParameters
+from reminders.constants import MAX_REMINDER_SECONDS, MAX_REMINDERS_PER_GUILD
+from reminders.reminders import Reminders, _ReminderDependencies
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from pathlib import Path
+
+NOW = datetime(2026, 6, 4, 12, tzinfo=UTC)
+HELP = (
+    "Format: $remind [amount of time] [message]. Example: $remind 1h check laundry\nSupport units: "
+    "s (seconds), m (minutes), h (hours), or d (days)."
+)
 
 
 def run[T](coro: Coroutine[object, object, T]) -> T:
     return asyncio.run(coro)
 
 
-class RecordingReminders(Reminders):
-    def __init__(self, reminders_json_path: Path) -> None:
-        super().__init__(SimpleNamespace(id=202, name="Guild"), reminders_json_path)
-        self.saved_count = 0
-        self.created_timers: list[tuple[ReminderRecord, float]] = []
+def command(*message: str, author_name: str = "Alice") -> CommandParameters:
+    return CommandParameters(
+        command="remind",
+        message=list(message),
+        created_at=NOW,
+        author_id=1,
+        author_name=author_name,
+        guild_id=202,
+        channel_id=303,
+    )
 
-    async def _save_reminders_unlocked(self) -> None:
-        self.saved_count += 1
 
-    def create_timer(self, reminder: ReminderRecord, delay_seconds: float) -> None:
-        self.created_timers.append((reminder, delay_seconds))
+def record(*, execution_time: str = "2026-06-04T12:05:00") -> dict[str, object]:
+    return {
+        "user_id": 1,
+        "name": "Alice",
+        "message": "check laundry",
+        "created_at": "2026-06-04T12:00:00",
+        "execution_time": execution_time,
+        "timezone": "utc",
+        "guild_id": 202,
+        "channel_id": 303,
+    }
+
+
+def persisted(path: Path) -> dict[str, object]:
+    return json.loads((path / "202.json").read_text(encoding="utf-8"))
+
+
+class ControlledSleep:
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+        self.waiting: asyncio.Queue[asyncio.Future[None]] = asyncio.Queue()
+        self.cancelled = 0
+
+    async def __call__(self, seconds: float) -> None:
+        self.calls.append(seconds)
+        future = asyncio.get_running_loop().create_future()
+        self.waiting.put_nowait(future)
+        try:
+            await future
+        except asyncio.CancelledError:
+            self.cancelled += 1
+            raise
+
+    async def advance(self) -> None:
+        future = await asyncio.wait_for(self.waiting.get(), timeout=1)
+        future.set_result(None)
+        await asyncio.sleep(0)
+
+
+class RecordingChannel(discord.abc.Messageable):
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, dict[str, object]]] = []
+
+    async def send(self, content: str, **kwargs: object) -> None:
+        self.sent.append((content, kwargs))
 
 
 class FakeGuild:
@@ -50,283 +98,303 @@ class FakeGuild:
 
     def __init__(self, channel: object) -> None:
         self.channel = channel
-        self.channel_lookup_count = 0
+        self.lookups: list[int] = []
 
-    def get_channel(self, _channel_id: int) -> object:
-        self.channel_lookup_count += 1
+    def get_channel(self, channel_id: int) -> object:
+        self.lookups.append(channel_id)
         return self.channel
 
 
-class RecordingDeliveryReminders(Reminders):
-    def __init__(self, channel: object, reminders_json_path: Path) -> None:
-        self.fake_guild = FakeGuild(channel)
-        super().__init__(self.fake_guild, reminders_json_path)
-        self.saved_count = 0
+def test_construction_creates_exact_file(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        reminders = await Reminders.create(FakeGuild(None), tmp_path)
+        assert persisted(tmp_path) == {"name": "Guild", "id": 202, "reminders": []}
+        await reminders.close()
+        await reminders.close()
 
-    async def _save_reminders_unlocked(self) -> None:
-        self.saved_count += 1
-
-
-class FlakyMessageable(discord.abc.Messageable):
-    def __init__(self, failures_before_success: int) -> None:
-        self.attempts = 0
-        self.failures_before_success = failures_before_success
-        self.sent_messages: list[str] = []
-        self.sent_kwargs: list[dict[str, object]] = []
-
-    async def send(self, *args: object, **kwargs: object) -> None:
-        self.attempts += 1
-        if self.failures_before_success > 0:
-            self.failures_before_success -= 1
-            response = SimpleNamespace(status=500, reason="Server Error")
-            raise discord.HTTPException(response, "send failed")
-        self.sent_messages.append(str(args[0]))
-        self.sent_kwargs.append(kwargs)
+    run(exercise())
 
 
-def make_reminder() -> ReminderRecord:
-    return ReminderRecord(
-        user_id=1,
-        name="Alice",
-        message="check laundry",
-        created_at=datetime.now(UTC).strftime(DATE_FORMAT),
-        execution_time=(datetime.now(UTC) + timedelta(minutes=5)).strftime(DATE_FORMAT),
-        timezone="utc",
-        guild_id=202,
-        channel_id=303,
-    )
+@pytest.mark.parametrize("message", [(), ("help",), ("list",), ("5m",), ("help", "ignored")])
+def test_help_and_argument_count_quirk(tmp_path: Path, message: tuple[str, ...]) -> None:
+    async def exercise() -> None:
+        reminders = await Reminders.create(FakeGuild(None), tmp_path)
+        before = (tmp_path / "202.json").read_bytes()
+        assert await reminders.handle(command(*message)) == HELP
+        assert (tmp_path / "202.json").read_bytes() == before
+        await reminders.close()
+
+    run(exercise())
 
 
-def patch_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
-    sleep_calls: list[float] = []
+@pytest.mark.parametrize(
+    ("duration", "response"),
+    [
+        ("2w", "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"),
+        ("soon", "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"),
+        ("xs", "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"),
+        (f"{MAX_REMINDER_SECONDS + 1}s", "Why are you using this feature for a reminder that far in the future?"),
+        ("0s", "Why are you trying to set a reminder for the past?"),
+        ("-1h", "Why are you trying to set a reminder for the past?"),
+    ],
+)
+def test_invalid_duration_does_not_write_or_schedule(tmp_path: Path, duration: str, response: str) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        reminders = await Reminders.create(FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(sleep=sleep))
+        before = (tmp_path / "202.json").stat()
+        assert await reminders.handle(command(duration, "stretch")) == response
+        assert (tmp_path / "202.json").stat() == before
+        await asyncio.sleep(0)
+        assert sleep.calls == []
+        await reminders.close()
 
-    async def fake_sleep(seconds: float) -> None:
-        sleep_calls.append(seconds)
-
-    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
-    return sleep_calls
-
-
-def test_parse_time_accepts_supported_units_and_rejects_bad_values() -> None:
-    assert parse_time("30s") == 30
-    assert parse_time("2m") == 120
-    assert parse_time("3h") == 10_800
-    assert parse_time("4d") == 345_600
-    assert parse_time("") is None
-    assert parse_time("10w") is None
-    assert parse_time("soon") is None
-
-
-def test_add_time_and_has_datetime_passed_support_datetime_strings() -> None:
-    start = datetime(2026, 6, 4, 12, 0, 0, tzinfo=UTC)
-    serialized_start = start.strftime(DATE_FORMAT)
-
-    assert add_time_to_date(start, 90) == datetime(2026, 6, 4, 12, 1, 30, tzinfo=UTC)
-    assert add_time_to_date(serialized_start, 90) == datetime(2026, 6, 4, 12, 1, 30, tzinfo=UTC)
-
-    future = (datetime.now(UTC) + timedelta(seconds=60)).strftime(DATE_FORMAT)
-    past = (datetime.now(UTC) - timedelta(seconds=60)).strftime(DATE_FORMAT)
-
-    future_result = has_datetime_passed(future)
-    past_result = has_datetime_passed(past)
-
-    assert future_result.result is False
-    assert 0 < future_result.seconds_until_execution <= 60
-    assert past_result.result is True
-    assert past_result.seconds_until_execution == -1
+    run(exercise())
 
 
-def test_create_reminder_rejects_invalid_durations_without_persisting(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-
-    unsupported = run(reminders.create_reminder("2w", ["stretch"], 1, 202, 303))
-    too_far = run(reminders.create_reminder(f"{MAX_REMINDER_SECONDS + 1}s", ["stretch"], 1, 202, 303))
-    past = run(reminders.create_reminder("0s", ["stretch"], 1, 202, 303))
-
-    assert unsupported == "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"
-    assert too_far == "Why are you using this feature for a reminder that far in the future?"
-    assert past == "Why are you trying to set a reminder for the past?"
-    assert reminders.saved_count == 0
-    assert reminders.created_timers == []
-    assert reminders.reminders.reminders == []
-
-
-def test_create_reminder_persists_record_and_schedules_timer(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-
-    result = run(reminders.create_reminder("5m", ["check", "laundry"], 1, 202, 303, user_name="Alice"))
-
-    assert result.startswith("Created reminder for Alice to go off at ")
-    assert result.endswith(" that says `check laundry`")
-    assert reminders.saved_count == 1
-    assert len(reminders.reminders.reminders) == 1
-    assert len(reminders.created_timers) == 1
-
-    reminder = reminders.reminders.reminders[0]
-    scheduled_reminder, delay_seconds = reminders.created_timers[0]
-
-    assert scheduled_reminder is reminder
-    assert delay_seconds == 300
-    assert reminder.user_id == 1
-    assert reminder.name == "Alice"
-    assert reminder.message == "check laundry"
-    assert reminder.guild_id == 202
-    assert reminder.channel_id == 303
-
-
-def test_create_reminder_uses_provided_user_name_without_fetching_user(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-
-    result = run(
-        reminders.create_reminder(
-            "5m",
-            ["check", "laundry"],
-            1,
-            202,
-            303,
-            user_name="Alice From Message",
+@pytest.mark.parametrize(("duration", "delay"), [("30s", 30), ("2M", 120), ("3h", 10800), ("4d", 345600)])
+def test_supported_durations_schedule(tmp_path: Path, duration: str, delay: int) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
         )
-    )
+        await reminders.handle(command(duration, "stretch"))
+        await asyncio.sleep(0)
+        assert sleep.calls == [delay]
+        await reminders.close()
 
-    assert result.startswith("Created reminder for Alice From Message to go off at ")
-    assert reminders.reminders.reminders[0].name == "Alice From Message"
-
-
-def test_create_reminder_falls_back_to_user_id_when_name_is_unavailable(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-
-    result = run(reminders.create_reminder("5m", ["check", "laundry"], 1, 202, 303))
-
-    assert result.startswith("Created reminder for 1 to go off at ")
-    assert reminders.reminders.reminders[0].name == "1"
+    run(exercise())
 
 
-def test_create_reminder_truncates_message_and_response_to_discord_limit(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-    long_message = "a" * (DISCORD_MESSAGE_LIMIT + 50)
+@pytest.mark.parametrize("author_name", ["Alice", ""])
+def test_create_persists_before_scheduling_and_formats_dates(tmp_path: Path, author_name: str) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        snapshots: list[dict[str, object]] = []
 
-    result = run(reminders.create_reminder("5m", [long_message], 1, 202, 303, user_name="Alice"))
+        async def observe_sleep(seconds: float) -> None:
+            snapshots.append(persisted(tmp_path))
+            await sleep(seconds)
 
-    assert len(result) == DISCORD_MESSAGE_LIMIT
-    assert result.endswith(TRUNCATION_SUFFIX)
-    assert len(reminders.reminders.reminders[0].message) == DISCORD_MESSAGE_LIMIT
-    assert reminders.reminders.reminders[0].message.endswith(TRUNCATION_SUFFIX)
-
-
-def test_list_reminders_truncates_to_discord_limit(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-    future_execution = (datetime.now(UTC) + timedelta(days=1)).strftime(DATE_FORMAT)
-    for index in range(25):
-        reminders.reminders.reminders.append(
-            ReminderRecord(
-                user_id=index,
-                name=f"User {index}",
-                message="a" * 100,
-                created_at=datetime.now(UTC).strftime(DATE_FORMAT),
-                execution_time=future_execution,
-                timezone="utc",
-                guild_id=202,
-                channel_id=303,
-            )
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=observe_sleep)
         )
-
-    result = run(reminders.list_reminders())
-
-    assert len(result) == DISCORD_MESSAGE_LIMIT
-    assert result.endswith(TRUNCATION_SUFFIX)
-
-
-def test_create_reminder_rejects_new_reminders_when_guild_limit_is_reached(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-    future_execution = (datetime.now(UTC) + timedelta(days=1)).strftime(DATE_FORMAT)
-    for index in range(MAX_REMINDERS_PER_GUILD):
-        reminders.reminders.reminders.append(
-            ReminderRecord(
-                user_id=index,
-                name=f"User {index}",
-                message="stretch",
-                created_at=datetime.now(UTC).strftime(DATE_FORMAT),
-                execution_time=future_execution,
-                timezone="utc",
-                guild_id=202,
-                channel_id=303,
-            )
+        name = author_name or "1"
+        assert await reminders.handle(command("5m", "check", "laundry", author_name=author_name)) == (
+            f"Created reminder for {name} to go off at 06/04/2026 @ 08:05AM that says `check laundry`"
         )
+        expected = {"name": "Guild", "id": 202, "reminders": [{**record(), "name": name}]}
+        assert persisted(tmp_path) == expected
+        await asyncio.sleep(0)
+        assert snapshots == [expected]
+        assert sleep.calls == [300]
+        assert await reminders.handle(command("list", "ignored")) == (
+            f"\nCreated by: {name}\nReminder date: 06/04/2026 @ 08:05AM\nReminder message: check laundry\n"
+        )
+        await reminders.close()
 
-    result = run(reminders.create_reminder("5m", ["stretch"], 1, 202, 303))
-
-    assert result == (
-        "Reminder limit reached. Delete or wait for a reminder to complete before creating a new one. Limit: "
-        f"{MAX_REMINDERS_PER_GUILD}"
-    )
-    assert reminders.saved_count == 0
-    assert reminders.created_timers == []
-    assert len(reminders.reminders.reminders) == MAX_REMINDERS_PER_GUILD
+    run(exercise())
 
 
-def test_send_message_retries_failures_and_removes_after_success(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_load_cleans_expired_and_schedules_active_records(tmp_path: Path) -> None:
+    source = {"name": "Guild", "id": 202, "reminders": [record(execution_time="2026-06-04T12:00:00"), record()]}
+    (tmp_path / "202.json").write_text(json.dumps(source), encoding="utf-8")
+
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
+        )
+        assert persisted(tmp_path) == {**source, "reminders": [record()]}
+        await asyncio.sleep(0)
+        assert sleep.calls == [300]
+        await reminders.close()
+
+    run(exercise())
+
+
+@pytest.mark.parametrize(
+    ("source", "error"),
+    [("{bad json", json.JSONDecodeError), ('{"id": 202, "name": "Guild", "reminders": [{}]}', ValidationError)],
+)
+def test_malformed_source_unchanged(tmp_path: Path, source: str, error: type[Exception]) -> None:
+    path = tmp_path / "202.json"
+    path.write_text(source, encoding="utf-8")
+    with pytest.raises(error):
+        run(Reminders.create(FakeGuild(None), tmp_path))
+    assert path.read_text(encoding="utf-8") == source
+
+
+def test_list_cleanup_and_empty_response(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        now = NOW
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: now, sleep=ControlledSleep())
+        )
+        assert await reminders.handle(command("list", "ignored")) == "No active reminds were found"
+        await reminders.handle(command("5m", "stretch"))
+        now = datetime(2026, 6, 5, tzinfo=UTC)
+        assert await reminders.handle(command("list", "ignored")) == "No active reminds were found"
+        assert persisted(tmp_path)["reminders"] == []
+        await reminders.close()
+
+    run(exercise())
+
+
+def test_truncation_and_guild_limit(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=ControlledSleep())
+        )
+        result = await reminders.handle(command("5m", "a" * (DISCORD_MESSAGE_LIMIT + 50)))
+        assert len(result) == DISCORD_MESSAGE_LIMIT
+        assert result.endswith(TRUNCATION_SUFFIX)
+        saved = persisted(tmp_path)["reminders"][0]["message"]
+        assert len(saved) == DISCORD_MESSAGE_LIMIT
+        assert saved.endswith(TRUNCATION_SUFFIX)
+        for _ in range(MAX_REMINDERS_PER_GUILD - 1):
+            await reminders.handle(command("5m", "stretch"))
+        before = (tmp_path / "202.json").read_bytes()
+        assert await reminders.handle(command("5m", "stretch")) == (
+            "Reminder limit reached. Delete or wait for a reminder to complete before creating a new one. Limit: 100"
+        )
+        assert (tmp_path / "202.json").read_bytes() == before
+        result = await reminders.handle(command("list", "ignored"))
+        assert len(result) == DISCORD_MESSAGE_LIMIT
+        assert result.endswith(TRUNCATION_SUFFIX)
+        await reminders.close()
+
+    run(exercise())
+
+
+@pytest.mark.parametrize("failures", [0, 2, 3])
+def test_delivery_retries_then_persists_removal(
+    tmp_path: Path, failures: int, caplog: pytest.LogCaptureFixture
 ) -> None:
-    sleep_calls = patch_sleep(monkeypatch)
-    channel = FlakyMessageable(failures_before_success=2)
-    reminders = RecordingDeliveryReminders(channel, tmp_path)
-    reminder = make_reminder()
-    reminders.reminders.reminders.append(reminder)
+    caplog.set_level(logging.INFO, logger="reminders.reminders")
 
-    run(reminders.send_message(reminder, 0))
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        channel = RecordingChannel()
+        guild = FakeGuild(channel)
+        attempts: list[tuple[object, int, str]] = []
 
-    assert channel.attempts == REMINDER_DELIVERY_ATTEMPTS
-    assert channel.sent_messages == ["<@1> reminder: check laundry"]
-    assert channel.sent_kwargs[0]["allowed_mentions"].to_dict() == {"users": [1], "parse": []}
-    assert reminders.reminders.reminders == []
-    assert reminders.saved_count == 1
-    assert sleep_calls == [0, REMINDER_DELIVERY_RETRY_DELAY_SECONDS, REMINDER_DELIVERY_RETRY_DELAY_SECONDS]
+        async def send(target: discord.abc.Messageable, user_id: int, content: str) -> None:
+            attempts.append((target, user_id, content))
+            if len(attempts) <= failures:
+                raise discord.HTTPException(SimpleNamespace(status=500, reason="Server Error"), "send failed")
 
+        reminders = await Reminders.create(
+            guild, tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep, send_reminder=send)
+        )
+        await reminders.handle(command("5m", "check", "laundry"))
+        for _ in range(min(failures + 1, 3)):
+            await sleep.advance()
+        assert attempts == [(channel, 1, "check laundry")] * min(failures + 1, 3)
+        assert guild.lookups == [303] * len(attempts)
+        assert sleep.calls == [300] + [60] * (len(attempts) - 1)
+        assert persisted(tmp_path)["reminders"] == []
+        before = (tmp_path / "202.json").stat()
+        await reminders.close()
+        assert (tmp_path / "202.json").stat() == before
 
-def test_send_message_removes_reminder_after_final_send_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    sleep_calls = patch_sleep(monkeypatch)
-    channel = FlakyMessageable(failures_before_success=REMINDER_DELIVERY_ATTEMPTS)
-    reminders = RecordingDeliveryReminders(channel, tmp_path)
-    reminder = make_reminder()
-    reminders.reminders.reminders.append(reminder)
-
-    with caplog.at_level(logging.ERROR):
-        run(reminders.send_message(reminder, 0))
-
-    assert channel.attempts == REMINDER_DELIVERY_ATTEMPTS
-    assert reminders.reminders.reminders == []
-    assert reminders.saved_count == 1
-    assert sleep_calls == [0, REMINDER_DELIVERY_RETRY_DELAY_SECONDS, REMINDER_DELIVERY_RETRY_DELAY_SECONDS]
-    assert "failed to send reminder after 3 attempts" in caplog.text
+    run(exercise())
+    assert sum(": saving:" in record.message for record in caplog.records) == 2
+    if failures == 3:
+        assert "failed to send reminder after 3 attempts" in caplog.text
 
 
 @pytest.mark.parametrize("channel", [None, object()])
-def test_send_message_retries_unavailable_channels_then_removes_reminder(
-    channel: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    sleep_calls = patch_sleep(monkeypatch)
-    reminders = RecordingDeliveryReminders(channel, tmp_path)
-    reminder = make_reminder()
-    reminders.reminders.reminders.append(reminder)
-
-    with caplog.at_level(logging.ERROR):
-        run(reminders.send_message(reminder, 0))
-
-    assert reminders.fake_guild.channel_lookup_count == REMINDER_DELIVERY_ATTEMPTS
-    assert reminders.reminders.reminders == []
-    assert reminders.saved_count == 1
-    assert sleep_calls == [0, REMINDER_DELIVERY_RETRY_DELAY_SECONDS, REMINDER_DELIVERY_RETRY_DELAY_SECONDS]
-    assert "failed to send reminder after 3 attempts" in caplog.text
-
-
-def test_close_cancels_pending_timer_tasks(tmp_path: Path) -> None:
-    async def exercise_close() -> tuple[int, int]:
-        reminders = Reminders(SimpleNamespace(id=202, name="Guild"), tmp_path)
-        reminders.create_timer(make_reminder(), 3_600)
-        task_count_before_close = len(reminders._timer_tasks)  # noqa: SLF001
+def test_unavailable_channel_retries_then_removes(tmp_path: Path, channel: object) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        guild = FakeGuild(channel)
+        reminders = await Reminders.create(
+            guild, tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
+        )
+        await reminders.handle(command("5m", "stretch"))
+        for _ in range(3):
+            await sleep.advance()
+        assert guild.lookups == [303, 303, 303]
+        assert sleep.calls == [300, 60, 60]
+        assert persisted(tmp_path)["reminders"] == []
         await reminders.close()
-        return task_count_before_close, len(reminders._timer_tasks)  # noqa: SLF001
 
-    assert run(exercise_close()) == (1, 0)
+    run(exercise())
+
+
+def test_default_sender_preserves_mention_policy(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        channel = RecordingChannel()
+        reminders = await Reminders.create(
+            FakeGuild(channel), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
+        )
+        await reminders.handle(command("5m", "check", "laundry"))
+        await sleep.advance()
+        content, kwargs = channel.sent[0]
+        assert content == "<@1> reminder: check laundry"
+        assert kwargs["allowed_mentions"].to_dict() == {"users": [1], "parse": []}
+        assert persisted(tmp_path)["reminders"] == []
+        await reminders.close()
+
+    run(exercise())
+
+
+def test_close_awaits_cancellation_and_retains_pending_records(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        guild = FakeGuild(RecordingChannel())
+        reminders = await Reminders.create(
+            guild, tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
+        )
+        await reminders.handle(command("5m", "stretch"))
+        await reminders.handle(command("1h", "rest"))
+        await asyncio.sleep(0)
+        before = (tmp_path / "202.json").read_bytes()
+        await reminders.close()
+        assert sleep.cancelled == 2
+        assert guild.lookups == []
+        assert (tmp_path / "202.json").read_bytes() == before
+        await reminders.close()
+
+    run(exercise())
+
+
+def test_cancelled_delivery_does_not_remove_or_retry(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        guild = FakeGuild(RecordingChannel())
+
+        async def send(_channel: discord.abc.Messageable, _user_id: int, _content: str) -> None:
+            raise asyncio.CancelledError
+
+        reminders = await Reminders.create(
+            guild, tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep, send_reminder=send)
+        )
+        await reminders.handle(command("5m", "stretch"))
+        before = (tmp_path / "202.json").read_bytes()
+        await sleep.advance()
+        await reminders.close()
+        assert sleep.calls == [300]
+        assert guild.lookups == [303]
+        assert (tmp_path / "202.json").read_bytes() == before
+
+    run(exercise())
+
+
+def test_command_cancellation_propagates(tmp_path: Path) -> None:
+    def cancelled_now() -> datetime:
+        raise asyncio.CancelledError
+
+    async def exercise() -> None:
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=cancelled_now)
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await reminders.handle(command("5m", "stretch"))
+        assert persisted(tmp_path)["reminders"] == []
+        await reminders.close()
+
+    run(exercise())


### PR DESCRIPTION
## Summary
- Move reminder grammar behind `Reminders.handle(CommandParameters)` and leave the runtime responsible for routing and guild lifecycle only.
- Keep persistence and owned timer tasks private; add immutable clock, sleep, and delivery dependencies for deterministic tests.
- Replace implementation-level tests with command, file, delivery, cancellation, and shutdown coverage while preserving existing responses and command quirks.

## Verification
- `uv run ruff format --check`
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest -q` — 109 passed

## Integration
First of three planned refactors. Merge before group activation ownership because both edit the runtime. No persisted schema, retry policy, mention policy, or Vault configuration changes.
