### PR TITLE
Deepen group activation ownership

### DIFF
--- a/src/bot_runtime.py
+++ b/src/bot_runtime.py
@@ -13,15 +13,7 @@ from weakref import WeakValueDictionary
 
 import discord
 
-from bot_state import (
-    GROUPS_FILENAME,
-    is_message_group_enabled,
-    load_group_records,
-    save_group_records,
-    set_message_group_enabled,
-    sync_group_records,
-    upsert_group_record,
-)
+from bot_state import GROUPS_FILENAME, GroupActivation
 from discord_messages import send_command_response
 from models import CommandParameters
 from reminders import Reminders
@@ -94,7 +86,7 @@ class BotRuntime:
 
         self._client = client
         self._command_delimiter = command_delimiter
-        self._groups_path = canonical_data_dir / GROUPS_FILENAME
+        self._activation = GroupActivation(canonical_data_dir / GROUPS_FILENAME)
         self._tag_path = canonical_data_dir / "tags"
         self._reminder_path = canonical_data_dir / "reminders"
         self._tag_factory = dependencies.tag_factory
@@ -123,16 +115,14 @@ class BotRuntime:
     async def on_ready(self) -> None:
         """Synchronize activation state, then initialize every visible guild."""
         _logger.info("We have logged in as %s", self._client.user)
-        await sync_group_records(self._client.guilds, self._client.private_channels, self._groups_path)
+        await self._activation.synchronize(self._client.guilds, self._client.private_channels)
         for guild in self._client.guilds:
             await self._initialize_guild(guild)
         _logger.info("Initializing Done")
 
     async def on_guild_join(self, guild: discord.Guild) -> None:
         """Preserve activation state across guild renames, then initialize the guild."""
-        records = await load_group_records(self._groups_path)
-        if upsert_group_record(records, guild.name, guild.id):
-            await save_group_records(records, self._groups_path)
+        await self._activation.record_join(guild)
         await self._initialize_guild(guild)
 
     async def on_guild_remove(self, guild: discord.Guild) -> None:
@@ -181,7 +171,7 @@ class BotRuntime:
     async def _handle_command_message(self, message: discord.Message, command_parts: list[str]) -> None:
         """Apply activation rules and dispatch parsed command parts."""
         if not command_parts:
-            if not await is_message_group_enabled(message, self._groups_path):
+            if not await self._activation.is_enabled(message):
                 return
             await self._send_command_response_or_log(message, await self._post_help(), "help")
             return
@@ -189,12 +179,12 @@ class BotRuntime:
         _logger.info("command: %s", command_parts)
         user_command = command_parts[0].lower()
         if user_command == ACTIVATE_COMMAND:
-            result = await set_message_group_enabled(message, enabled=True, groups_path=self._groups_path)
+            result = await self._activation.set_enabled(message, enabled=True)
             await self._send_command_response_or_log(message, result, user_command)
-        elif not await is_message_group_enabled(message, self._groups_path):
+        elif not await self._activation.is_enabled(message):
             return
         elif user_command in {DEACTIVE_COMMAND, DEACTIVATE_COMMAND}:
-            result = await set_message_group_enabled(message, enabled=False, groups_path=self._groups_path)
+            result = await self._activation.set_enabled(message, enabled=False)
             await self._send_command_response_or_log(message, result, user_command)
         elif user_command in self._commands:
             result = await self._dispatch_command(message, user_command, command_parts[1:])

--- a/src/bot_runtime.py
+++ b/src/bot_runtime.py
@@ -25,7 +25,6 @@ from bot_state import (
 from discord_messages import send_command_response
 from models import CommandParameters
 from reminders import Reminders
-from reminders.constants import MIN_REMIND_ARGUMENTS
 from tags import Tags
 
 CommandHandler = Callable[[CommandParameters], Awaitable[str]]
@@ -293,19 +292,7 @@ class BotRuntime:
         reminder_handler = self._reminders.get(guild_id)
         if reminder_handler is None:
             return ""
-        command_message = parameters.message
-        time = command_message[0] if command_message else "help"
-        message = command_message[1:]
-        if len(command_message) < MIN_REMIND_ARGUMENTS:
-            time = "help"
-        return await reminder_handler.create_reminder(
-            time,
-            message,
-            parameters.author_id,
-            guild_id,
-            channel_id,
-            user_name=parameters.author_name,
-        )
+        return await reminder_handler.handle(parameters)
 
     async def _mock(self, parameters: CommandParameters) -> str:
         """Return the command message in alternating case."""

--- a/src/bot_state.py
+++ b/src/bot_state.py
@@ -1,7 +1,8 @@
-"""Persistence helpers for bot activation state."""
+"""Owned group activation transactions and data-directory configuration."""
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from pathlib import Path
@@ -74,12 +75,7 @@ def get_state_paths() -> tuple[Path, Path]:
     return data_dir / "tags", data_dir / "reminders"
 
 
-def get_groups_path() -> Path:
-    """Return the path to the group and DM activation state file."""
-    return get_data_dir() / GROUPS_FILENAME
-
-
-def load_group_records_sync(groups_path: Path) -> dict[str, dict[str, Any]]:
+def _load_group_records_sync(groups_path: Path) -> dict[str, dict[str, Any]]:
     """Return persisted group activation records."""
     if not groups_path.exists():
         return {}
@@ -91,24 +87,14 @@ def load_group_records_sync(groups_path: Path) -> dict[str, dict[str, Any]]:
     return records
 
 
-async def load_group_records(groups_path: Path | None = None) -> dict[str, dict[str, Any]]:
-    """Load group activation records."""
-    return load_group_records_sync(groups_path or get_groups_path())
-
-
-def save_group_records_sync(groups_path: Path, records: dict[str, dict[str, Any]]) -> None:
+def _save_group_records_sync(groups_path: Path, records: dict[str, dict[str, Any]]) -> None:
     """Persist group activation records."""
     groups_path.parent.mkdir(parents=True, exist_ok=True)
     with atomic_write(groups_path, overwrite=True, encoding="utf-8") as groups_file:
         groups_file.write(json.dumps(records, sort_keys=True, indent=2))
 
 
-async def save_group_records(records: dict[str, dict[str, Any]], groups_path: Path | None = None) -> None:
-    """Save group activation records."""
-    save_group_records_sync(groups_path or get_groups_path(), records)
-
-
-def unique_group_name(records: dict[str, dict[str, Any]], name: str, group_id: str) -> str:
+def _unique_group_name(records: dict[str, dict[str, Any]], name: str, group_id: str) -> str:
     """Return a stable name key for a group record."""
     existing_record = records.get(name)
     if existing_record is None or str(existing_record.get("id")) == group_id:
@@ -116,14 +102,14 @@ def unique_group_name(records: dict[str, dict[str, Any]], name: str, group_id: s
     return f"{name} ({group_id})"
 
 
-def upsert_group_record(records: dict[str, dict[str, Any]], name: str, group_id: int | str) -> bool:
+def _upsert_group_record(records: dict[str, dict[str, Any]], name: str, group_id: int | str) -> bool:
     """Add or rename a group record while preserving its enabled value."""
     group_id = str(group_id)
     existing_key = next((key for key, record in records.items() if str(record.get("id")) == group_id), None)
     if existing_key is not None:
         record = records[existing_key]
         enabled = bool(record.get("enabled", True))
-        name = unique_group_name(records, name, group_id)
+        name = _unique_group_name(records, name, group_id)
         if existing_key != name:
             del records[existing_key]
             records[name] = {"enabled": enabled, "id": group_id}
@@ -134,11 +120,11 @@ def upsert_group_record(records: dict[str, dict[str, Any]], name: str, group_id:
             return True
         return False
 
-    records[unique_group_name(records, name, group_id)] = {"enabled": True, "id": group_id}
+    records[_unique_group_name(records, name, group_id)] = {"enabled": True, "id": group_id}
     return True
 
 
-def get_private_channel_name(channel: object) -> str:
+def _get_private_channel_name(channel: object) -> str:
     """Return a display name for a Discord DM or group DM channel."""
     recipient = getattr(channel, "recipient", None)
     if recipient is not None and getattr(recipient, "name", None):
@@ -153,46 +139,14 @@ def get_private_channel_name(channel: object) -> str:
     return f"DM: {getattr(channel, 'id', 'unknown')}"
 
 
-def get_message_group_name_and_id(message: MessageContext) -> tuple[str, int]:
+def _get_message_group_name_and_id(message: MessageContext) -> tuple[str, int]:
     """Return the group state identity for an incoming Discord message."""
     if message.guild is not None:
         return message.guild.name, message.guild.id
-    return get_private_channel_name(message.channel), message.channel.id
+    return _get_private_channel_name(message.channel), message.channel.id
 
 
-async def sync_group_records(
-    guilds: Sequence[GroupIdentity],
-    private_channels: Sequence[MessageChannel],
-    groups_path: Path | None = None,
-) -> None:
-    """Write all visible guilds and cached DMs to the group activation file."""
-    groups_path = groups_path or get_groups_path()
-    records = await load_group_records(groups_path)
-    changed = False
-    for guild in guilds:
-        changed = upsert_group_record(records, guild.name, guild.id) or changed
-    for channel in private_channels:
-        changed = upsert_group_record(records, get_private_channel_name(channel), channel.id) or changed
-    if changed or not groups_path.exists():
-        await save_group_records(records, groups_path)
-
-
-async def is_message_group_enabled(message: MessageContext, groups_path: Path | None = None) -> bool:
-    """Return whether the message context is enabled for bot command responses."""
-    name, group_id = get_message_group_name_and_id(message)
-    groups_path = groups_path or get_groups_path()
-    records = await load_group_records(groups_path)
-    changed = upsert_group_record(records, name, group_id)
-    enabled = next(
-        (bool(record.get("enabled", True)) for record in records.values() if str(record.get("id")) == str(group_id)),
-        True,
-    )
-    if changed:
-        await save_group_records(records, groups_path)
-    return enabled
-
-
-def can_manage_group_state(message: MessageContext) -> bool:
+def _can_manage_group_state(message: MessageContext) -> bool:
     """Return whether the command author can change the current group state."""
     if message.guild is None:
         return True
@@ -200,24 +154,67 @@ def can_manage_group_state(message: MessageContext) -> bool:
     return bool(getattr(permissions, "administrator", False) or getattr(permissions, "manage_guild", False))
 
 
-async def set_message_group_enabled(
-    message: MessageContext,
-    *,
-    enabled: bool,
-    groups_path: Path | None = None,
-) -> str:
-    """Enable or disable command responses for the current Discord context."""
-    if not can_manage_group_state(message):
-        return "Only server admins can activate or deactive this bot."
+class GroupActivation:
+    """Own identity, permissions, and serialized activation file transactions."""
 
-    name, group_id = get_message_group_name_and_id(message)
-    groups_path = groups_path or get_groups_path()
-    records = await load_group_records(groups_path)
-    upsert_group_record(records, name, group_id)
-    for record in records.values():
-        if str(record.get("id")) == str(group_id):
-            record["enabled"] = enabled
-            break
-    await save_group_records(records, groups_path)
-    state = "activated" if enabled else "deactived"
-    return f"{name} has been {state}."
+    def __init__(self, groups_path: Path) -> None:
+        """Keep one explicit persistence path and a lock for its transactions."""
+        self._groups_path = groups_path
+        self._lock = asyncio.Lock()
+
+    async def synchronize(
+        self,
+        guilds: Sequence[GroupIdentity],
+        private_channels: Sequence[MessageChannel],
+    ) -> None:
+        """Synchronize visible Groups without losing activation or invisible records."""
+        async with self._lock:
+            records = _load_group_records_sync(self._groups_path)
+            changed = False
+            for guild in guilds:
+                changed = _upsert_group_record(records, guild.name, guild.id) or changed
+            for channel in private_channels:
+                changed = _upsert_group_record(records, _get_private_channel_name(channel), channel.id) or changed
+            if changed or not self._groups_path.exists():
+                _save_group_records_sync(self._groups_path, records)
+
+    async def record_join(self, guild: GroupIdentity) -> None:
+        """Record a join or rename while preserving the Group's activation choice."""
+        async with self._lock:
+            records = _load_group_records_sync(self._groups_path)
+            if _upsert_group_record(records, guild.name, guild.id):
+                _save_group_records_sync(self._groups_path, records)
+
+    async def is_enabled(self, message: MessageContext) -> bool:
+        """Return activation, persisting a missing Group with its current default."""
+        async with self._lock:
+            name, group_id = _get_message_group_name_and_id(message)
+            records = _load_group_records_sync(self._groups_path)
+            changed = _upsert_group_record(records, name, group_id)
+            enabled = next(
+                (
+                    bool(record.get("enabled", True))
+                    for record in records.values()
+                    if str(record.get("id")) == str(group_id)
+                ),
+                True,
+            )
+            if changed:
+                _save_group_records_sync(self._groups_path, records)
+            return enabled
+
+    async def set_enabled(self, message: MessageContext, *, enabled: bool) -> str:
+        """Authorize, persist, and describe an activation change as one transaction."""
+        async with self._lock:
+            if not _can_manage_group_state(message):
+                return "Only server admins can activate or deactive this bot."
+            name, group_id = _get_message_group_name_and_id(message)
+            records = _load_group_records_sync(self._groups_path)
+            _upsert_group_record(records, name, group_id)
+            for record in records.values():
+                if str(record.get("id")) == str(group_id):
+                    record["enabled"] = enabled
+                    break
+            _save_group_records_sync(self._groups_path, records)
+            state = "activated" if enabled else "deactived"
+            return f"{name} has been {state}."

--- a/src/reminders/reminders.py
+++ b/src/reminders/reminders.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
 import discord
@@ -21,16 +24,37 @@ from .constants import (
     HUMAN_DATE_FORMAT,
     MAX_REMINDER_SECONDS,
     MAX_REMINDERS_PER_GUILD,
+    MIN_REMIND_ARGUMENTS,
     REMINDER_DELIVERY_ATTEMPTS,
     REMINDER_DELIVERY_RETRY_DELAY_SECONDS,
 )
 from .models import DatetimePassedResult, ReminderFile, ReminderRecord
 
+if TYPE_CHECKING:
+    from models import CommandParameters
+
 _logger = logging.getLogger(__name__)
 DISPLAY_TIMEZONE = ZoneInfo("America/New_York")
 
+Now = Callable[[], datetime]
+Sleep = Callable[[float], Awaitable[None]]
+ReminderSender = Callable[[discord.abc.Messageable, int, str], Awaitable[None]]
 
-def parse_time(time: str) -> int | None:
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+@dataclass(frozen=True, slots=True)
+class _ReminderDependencies:
+    """Private clock, delay, and delivery adapters for reminder tests."""
+
+    now: Now = _utc_now
+    sleep: Sleep = asyncio.sleep
+    send_reminder: ReminderSender = send_reminder_response
+
+
+def _parse_time(time: str) -> int | None:
     """Convert a compact duration string into seconds."""
     if not time:
         return None
@@ -49,16 +73,15 @@ def parse_time(time: str) -> int | None:
     return amount * multiplier
 
 
-def add_time_to_date(date: datetime | str, seconds: int) -> datetime:
+def _add_time_to_date(date: datetime | str, seconds: int) -> datetime:
     """Add seconds to a UTC datetime or serialized datetime string."""
     if isinstance(date, str):
         date = datetime.strptime(date, DATE_FORMAT).replace(tzinfo=UTC)
     return date + timedelta(seconds=seconds)
 
 
-def has_datetime_passed(planned_execution_date: datetime | str) -> DatetimePassedResult:
+def _has_datetime_passed(planned_execution_date: datetime | str, current_datetime: datetime) -> DatetimePassedResult:
     """Report whether a planned UTC execution datetime has passed."""
-    current_datetime = datetime.now(UTC)
     if isinstance(planned_execution_date, str):
         planned_execution_date = datetime.strptime(planned_execution_date, DATE_FORMAT).replace(tzinfo=UTC)
     _logger.info(
@@ -87,9 +110,9 @@ def has_datetime_passed(planned_execution_date: datetime | str) -> DatetimePasse
     return DatetimePassedResult(result=True, seconds_until_execution=-1)
 
 
-def parse_reminder_delay(seconds: str) -> tuple[int | None, str | None]:
+def _parse_reminder_delay(seconds: str) -> tuple[int | None, str | None]:
     """Return a valid reminder delay or the user-facing validation error."""
-    delay_seconds = parse_time(seconds)
+    delay_seconds = _parse_time(seconds)
     if delay_seconds is None:
         return None, "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"
     if delay_seconds > MAX_REMINDER_SECONDS:
@@ -102,75 +125,83 @@ def parse_reminder_delay(seconds: str) -> tuple[int | None, str | None]:
 class Reminders:
     """Manage persisted reminders and scheduled reminder messages for a guild."""
 
-    def __init__(self, guild: discord.Guild, reminders_json_path: str | Path) -> None:
+    def __init__(
+        self,
+        guild: discord.Guild,
+        reminders_json_path: str | Path,
+        *,
+        _dependencies: _ReminderDependencies | None = None,
+    ) -> None:
         """Initialize paths and default reminder state for a guild."""
-        self.guild = guild
-        self.reminders_json_path = Path(reminders_json_path)
-        self.reminders_json_file = self.reminders_json_path / f"{guild.id}.json"
-        self.reminders = ReminderFile(name=guild.name, id=guild.id)
+        self._dependencies = replace(_dependencies) if _dependencies is not None else _ReminderDependencies()
+        self._guild = guild
+        self._reminders_json_path = Path(reminders_json_path)
+        self._reminders_json_file = self._reminders_json_path / f"{guild.id}.json"
+        self._reminders = ReminderFile(name=guild.name, id=guild.id)
         self._timer_tasks: set[asyncio.Task[None]] = set()
         self._reminder_lock = asyncio.Lock()
 
     @classmethod
-    async def create(cls, guild: discord.Guild, reminders_json_path: str | Path) -> Reminders:
+    async def create(
+        cls,
+        guild: discord.Guild,
+        reminders_json_path: str | Path,
+        *,
+        _dependencies: _ReminderDependencies | None = None,
+    ) -> Reminders:
         """Create a reminder handler and schedule any pending reminders."""
-        reminder_handler = cls(guild, reminders_json_path)
-        reminder_handler.reminders = await reminder_handler.load_reminders()
-        await reminder_handler.clean_reminders()
-        await reminder_handler.parse_reminders()
+        reminder_handler = cls(guild, reminders_json_path, _dependencies=_dependencies)
+        reminder_handler._reminders = await reminder_handler._load_reminders()
+        await reminder_handler._clean_reminders()
+        await reminder_handler._parse_reminders()
         return reminder_handler
 
-    async def create_json(self) -> None:
+    async def _create_json(self) -> None:
         """Create the reminders directory and guild JSON file when missing."""
 
         def create_json_sync() -> None:
-            self.reminders_json_path.mkdir(parents=True, exist_ok=True)
-            create_json = ReminderFile(name=self.guild.name, id=self.guild.id)
+            self._reminders_json_path.mkdir(parents=True, exist_ok=True)
+            initial_state = ReminderFile(name=self._guild.name, id=self._guild.id)
             try:
-                with self.reminders_json_file.open("x", encoding="utf-8") as reminders_file:
-                    json.dump(create_json.model_dump(mode="json"), reminders_file)
+                with self._reminders_json_file.open("x", encoding="utf-8") as reminders_file:
+                    json.dump(initial_state.model_dump(mode="json"), reminders_file)
             except FileExistsError:
                 return
-            _logger.info("%s: created: %s", self.guild.name, self.reminders_json_file)
+            _logger.info("%s: created: %s", self._guild.name, self._reminders_json_file)
 
         await asyncio.to_thread(create_json_sync)
 
-    async def load_reminders(self) -> ReminderFile:
+    async def _load_reminders(self) -> ReminderFile:
         """Return the guild's reminders JSON data."""
-        await self.create_json()
-        _logger.info("%s: loading: %s", self.guild.name, self.reminders_json_file)
-        with self.reminders_json_file.open(encoding="utf-8") as reminders:
+        await self._create_json()
+        _logger.info("%s: loading: %s", self._guild.name, self._reminders_json_file)
+        with self._reminders_json_file.open(encoding="utf-8") as reminders:
             return ReminderFile.model_validate(json.load(reminders))
-
-    async def save_reminders(self) -> None:
-        """Write the guild's reminders to disk."""
-        async with self._reminder_lock:
-            await self._save_reminders_unlocked()
 
     async def _save_reminders_unlocked(self) -> None:
         """Write reminders to disk while the caller holds the reminder lock."""
-        _logger.info("%s: saving: %s", self.guild.name, self.reminders_json_file)
-        with atomic_write(self.reminders_json_file, overwrite=True, encoding="utf-8") as reminders_file:
-            reminders_file.write(json.dumps(self.reminders.model_dump(mode="json"), sort_keys=True, indent=2))
+        _logger.info("%s: saving: %s", self._guild.name, self._reminders_json_file)
+        with atomic_write(self._reminders_json_file, overwrite=True, encoding="utf-8") as reminders_file:
+            reminders_file.write(json.dumps(self._reminders.model_dump(mode="json"), sort_keys=True, indent=2))
 
-    async def clean_reminders(self) -> None:
+    async def _clean_reminders(self) -> None:
         """Remove expired reminders and persist the cleaned reminder list."""
-        _logger.info("%s: cleaning: %s", self.guild.name, self.reminders_json_file)
+        _logger.info("%s: cleaning: %s", self._guild.name, self._reminders_json_file)
         async with self._reminder_lock:
             active_reminders = [
                 reminder
-                for reminder in self.reminders.reminders
-                if not has_datetime_passed(reminder.execution_time).result
+                for reminder in self._reminders.reminders
+                if not _has_datetime_passed(reminder.execution_time, self._dependencies.now()).result
             ]
-            if len(active_reminders) != len(self.reminders.reminders):
-                self.reminders.reminders = active_reminders
+            if len(active_reminders) != len(self._reminders.reminders):
+                self._reminders.reminders = active_reminders
                 await self._save_reminders_unlocked()
 
-    async def list_reminders(self) -> str:
+    async def _list_reminders(self) -> str:
         """Return a formatted list of active reminders."""
-        await self.clean_reminders()
+        await self._clean_reminders()
         async with self._reminder_lock:
-            reminders = list(self.reminders.reminders)
+            reminders = list(self._reminders.reminders)
         messages: list[str] = []
         for reminder in reminders:
             reminder_date = datetime.strptime(reminder.execution_time, DATE_FORMAT).replace(tzinfo=UTC)
@@ -182,41 +213,41 @@ class Reminders:
             return "No active reminds were found"
         return truncate_discord_message("".join(messages))
 
-    async def parse_reminders(self) -> None:
+    async def _parse_reminders(self) -> None:
         """Schedule all currently persisted reminders."""
-        _logger.info("%s: parse_reminders()", self.guild.name)
-        _logger.info("%s: %s", self.guild.name, self.reminders)
+        _logger.info("%s: parse_reminders()", self._guild.name)
+        _logger.info("%s: %s", self._guild.name, self._reminders)
         async with self._reminder_lock:
-            reminders = list(self.reminders.reminders)
+            reminders = list(self._reminders.reminders)
         for reminder in reminders:
-            await self.parse_reminder(reminder)
+            await self._parse_reminder(reminder)
 
-    async def parse_reminder(self, reminder: ReminderRecord) -> None:
+    async def _parse_reminder(self, reminder: ReminderRecord) -> None:
         """Schedule a reminder if it has not already expired."""
-        _logger.info("%s: parse_reminder()", self.guild.name)
-        passed_result = has_datetime_passed(reminder.execution_time)
+        _logger.info("%s: parse_reminder()", self._guild.name)
+        passed_result = _has_datetime_passed(reminder.execution_time, self._dependencies.now())
         if not passed_result.result:
-            self.create_timer(reminder, passed_result.seconds_until_execution)
+            self._create_timer(reminder, passed_result.seconds_until_execution)
         else:
             _logger.info(
                 "%s: parse_reminder() - reminder for %s that says %s alredy expired",
-                self.guild.name,
+                self._guild.name,
                 reminder.name,
                 reminder.message,
             )
 
-    def create_timer(
+    def _create_timer(
         self,
         reminder: ReminderRecord,
         delay_seconds: float,
     ) -> None:
         """Create an async timer that sends a reminder message later."""
-        task = asyncio.create_task(self.send_message(reminder, delay_seconds))
+        task = asyncio.create_task(self._send_message(reminder, delay_seconds))
         self._timer_tasks.add(task)
         task.add_done_callback(self._timer_finished)
         _logger.info(
             "%s: created timer for %s that will execute in %s seconds",
-            self.guild.name,
+            self._guild.name,
             reminder.name,
             delay_seconds,
         )
@@ -228,7 +259,7 @@ class Reminders:
             return
         exception = task.exception()
         if exception is not None:
-            _logger.error("%s: reminder timer failed", self.guild.name, exc_info=exception)
+            _logger.error("%s: reminder timer failed", self._guild.name, exc_info=exception)
 
     async def close(self) -> None:
         """Cancel and await all scheduled timers owned by this guild handler."""
@@ -238,41 +269,41 @@ class Reminders:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
 
-    async def remove_reminder(self, reminder: ReminderRecord) -> None:
+    async def _remove_reminder(self, reminder: ReminderRecord) -> None:
         """Remove a completed reminder from memory and disk."""
         async with self._reminder_lock:
             try:
-                self.reminders.reminders.remove(reminder)
+                self._reminders.reminders.remove(reminder)
             except ValueError:
-                _logger.info("%s: reminder was already removed: %s", self.guild.name, reminder)
+                _logger.info("%s: reminder was already removed: %s", self._guild.name, reminder)
                 return
             await self._save_reminders_unlocked()
 
-    async def send_message(self, reminder: ReminderRecord, seconds: float) -> None:
+    async def _send_message(self, reminder: ReminderRecord, seconds: float) -> None:
         """Wait for the requested delay, then send the reminder to a channel."""
-        await asyncio.sleep(seconds)
+        await self._dependencies.sleep(seconds)
         for attempt in range(1, REMINDER_DELIVERY_ATTEMPTS + 1):
             if await self._try_send_reminder(reminder, attempt):
-                await self.remove_reminder(reminder)
+                await self._remove_reminder(reminder)
                 return
             if attempt < REMINDER_DELIVERY_ATTEMPTS:
-                await asyncio.sleep(REMINDER_DELIVERY_RETRY_DELAY_SECONDS)
+                await self._dependencies.sleep(REMINDER_DELIVERY_RETRY_DELAY_SECONDS)
 
         _logger.error(
             "%s: failed to send reminder after %s attempts: %s",
-            self.guild.name,
+            self._guild.name,
             REMINDER_DELIVERY_ATTEMPTS,
             reminder,
         )
-        await self.remove_reminder(reminder)
+        await self._remove_reminder(reminder)
 
     async def _try_send_reminder(self, reminder: ReminderRecord, attempt: int) -> bool:
         """Try to send a reminder once."""
-        channel = self.guild.get_channel(reminder.channel_id)
+        channel = self._guild.get_channel(reminder.channel_id)
         if channel is None:
             _logger.warning(
                 "%s: channel %s was not found for reminder send attempt %s",
-                self.guild.name,
+                self._guild.name,
                 reminder.channel_id,
                 attempt,
             )
@@ -280,33 +311,30 @@ class Reminders:
         if not isinstance(channel, discord.abc.Messageable):
             _logger.warning(
                 "%s: channel %s cannot receive reminder messages on attempt %s",
-                self.guild.name,
+                self._guild.name,
                 reminder.channel_id,
                 attempt,
             )
             return False
         try:
-            await send_reminder_response(channel, reminder.user_id, reminder.message)
+            await self._dependencies.send_reminder(channel, reminder.user_id, reminder.message)
         except discord.HTTPException:
             _logger.exception(
                 "%s: failed to send reminder to channel %s on attempt %s",
-                self.guild.name,
+                self._guild.name,
                 reminder.channel_id,
                 attempt,
             )
             return False
         return True
 
-    async def create_reminder(
-        self,
-        seconds: str,
-        message: list[str],
-        user_id: int,
-        guild_id: int,
-        channel_id: int,
-        user_name: str | None = None,
-    ) -> str:
-        """Create, persist, and schedule a reminder from a user command."""
+    async def handle(self, parameters: CommandParameters) -> str:
+        """Interpret a command and own validation, persistence, and scheduling."""
+        command_message = parameters.message
+        seconds = command_message[0] if command_message else "help"
+        message = command_message[1:]
+        if len(command_message) < MIN_REMIND_ARGUMENTS:
+            seconds = "help"
         match seconds:
             case "help":
                 return (
@@ -314,39 +342,39 @@ class Reminders:
                     "s (seconds), m (minutes), h (hours), or d (days)."
                 )
             case "list":
-                return await self.list_reminders()
+                return await self._list_reminders()
             case _:
-                delay_seconds, error_message = parse_reminder_delay(seconds)
+                delay_seconds, error_message = _parse_reminder_delay(seconds)
         if delay_seconds is None:
             if error_message is None:
                 msg = "reminder delay validation failed without an error message"
                 raise ValueError(msg)
             return error_message
         reminder_message = truncate_text(" ".join(message), DISCORD_MESSAGE_LIMIT)
-        created_at = datetime.now(UTC)
-        reminder_user_name = user_name or str(user_id)
+        created_at = self._dependencies.now()
+        reminder_user_name = parameters.author_name or str(parameters.author_id)
         reminder = ReminderRecord(
-            user_id=user_id,
+            user_id=parameters.author_id,
             name=reminder_user_name,
             message=reminder_message,
             created_at=created_at.strftime(DATE_FORMAT),
-            execution_time=add_time_to_date(created_at, delay_seconds).strftime(DATE_FORMAT),
+            execution_time=_add_time_to_date(created_at, delay_seconds).strftime(DATE_FORMAT),
             timezone="utc",
-            guild_id=guild_id,
-            channel_id=channel_id,
+            guild_id=parameters.guild_id if parameters.guild_id is not None else self._guild.id,
+            channel_id=parameters.channel_id,
         )
         async with self._reminder_lock:
-            if len(self.reminders.reminders) >= MAX_REMINDERS_PER_GUILD:
+            if len(self._reminders.reminders) >= MAX_REMINDERS_PER_GUILD:
                 return (
                     "Reminder limit reached. Delete or wait for a reminder to complete before creating a new one. "
                     f"Limit: {MAX_REMINDERS_PER_GUILD}"
                 )
-            self.reminders.reminders.append(reminder)
+            self._reminders.reminders.append(reminder)
             await self._save_reminders_unlocked()
         execution_time = (
             (created_at + timedelta(seconds=delay_seconds)).astimezone(DISPLAY_TIMEZONE).strftime(HUMAN_DATE_FORMAT)
         )
-        self.create_timer(reminder, delay_seconds)
+        self._create_timer(reminder, delay_seconds)
         return truncate_discord_message(
             f"Created reminder for {reminder_user_name} to go off at {execution_time} that says `{reminder_message}`"
         )

--- a/tests/test_bot_runtime.py
+++ b/tests/test_bot_runtime.py
@@ -15,12 +15,11 @@ import pytest
 
 from bot_runtime import GENERIC_COMMAND_ERROR, BotRuntime, _RuntimeDependencies
 from bot_state import DATA_DIR_ENV_VAR
+from models import CommandParameters
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from pathlib import Path
-
-    from models import CommandParameters
 
 
 def run[T](coro: Coroutine[object, object, T]) -> T:
@@ -65,15 +64,15 @@ class RecordingReminder:
     def __init__(self, *, close_error: Exception | None = None) -> None:
         self.close_error = close_error
         self.closed = False
-        self.create_calls: list[tuple[object, ...]] = []
+        self.parameters: list[CommandParameters] = []
 
     async def close(self) -> None:
         self.closed = True
         if self.close_error is not None:
             raise self.close_error
 
-    async def create_reminder(self, *args: object, **kwargs: object) -> str:
-        self.create_calls.append((*args, kwargs))
+    async def handle(self, parameters: CommandParameters) -> str:
+        self.parameters.append(parameters)
         return "reminder response"
 
 
@@ -506,17 +505,26 @@ def test_tag_command_parameters_preserve_message_context_and_attachment(tmp_path
     assert parameters.fetch_user_func is None
 
 
-def test_reminder_command_routes_to_initialized_guild_handler(tmp_path: Path) -> None:
+@pytest.mark.parametrize("arguments", ["5m drink water", "", "list", "help ignored", "bad duration"])
+def test_reminder_command_routes_to_initialized_guild_handler(tmp_path: Path, arguments: str) -> None:
     guild = make_guild(910)
     runtime, _client, factories = make_runtime(tmp_path, client=FakeClient(guilds=[guild]))
     channel = RecordingChannel()
     run(runtime.on_ready())
 
-    run(runtime.on_message(make_message("$remind 5m drink water", guild=guild, channel=channel)))
+    run(runtime.on_message(make_message(f"$remind {arguments}", guild=guild, channel=channel)))
 
     assert sent_text(channel) == ["reminder response"]
-    assert factories.reminders[guild.id].create_calls == [
-        ("5m", ["drink", "water"], 123, 910, 789, {"user_name": "Alice"})
+    assert factories.reminders[guild.id].parameters == [
+        CommandParameters(
+            command="remind",
+            message=arguments.split(),
+            created_at=datetime(2026, 6, 4, tzinfo=UTC),
+            author_id=123,
+            author_name="Alice",
+            guild_id=910,
+            channel_id=789,
+        )
     ]
 
 
@@ -678,3 +686,57 @@ def test_malformed_guild_registry_file_is_retained_while_other_registry_initiali
     assert bad_file.read_text(encoding="utf-8") == "{bad json"
     other_file = tmp_path / ("reminders" if bad_registry == "tags" else "tags") / f"{guild.id}.json"
     assert other_file.exists()
+
+
+@pytest.mark.parametrize("command", ["remind", "tag"])
+def test_guild_commands_preserve_missing_guild_response(tmp_path: Path, command: str) -> None:
+    runtime, _client, _factories = make_runtime(tmp_path)
+    channel = RecordingChannel()
+    message = make_message(f"${command}", channel=channel)
+    message.guild = None
+    run(runtime.on_message(message))
+    expected = (
+        "guild_id (None) or channel_id 789 is None." if command == "remind" else "unable to get tag. guild_id is None"
+    )
+    assert sent_text(channel) == [expected]
+
+
+def test_missing_reminder_handler_keeps_empty_response(tmp_path: Path) -> None:
+    runtime, _client, _factories = make_runtime(tmp_path)
+    channel = RecordingChannel()
+    run(runtime.on_message(make_message("$remind 5m stretch", channel=channel)))
+    assert sent_text(channel) == [""]
+
+
+def test_guild_removal_discards_both_registries_before_awaiting_shutdown(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        class WaitingReminder(RecordingReminder):
+            async def close(self) -> None:
+                entered.set()
+                await release.wait()
+
+        async def make_reminder(_guild: object, _path: Path) -> WaitingReminder:
+            return WaitingReminder()
+
+        guild = make_guild()
+        factories = RecordingFactories()
+        runtime = BotRuntime(
+            FakeClient(guilds=[guild]),
+            command_delimiter="$",
+            data_dir=tmp_path,
+            _dependencies=_RuntimeDependencies(tag_factory=factories.make_tag, reminder_factory=make_reminder),
+        )
+        await runtime.on_ready()
+        removal = asyncio.create_task(runtime.on_guild_remove(guild))
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        channel = RecordingChannel()
+        await runtime.on_message(make_message("$tag launch", channel=channel))
+        await runtime.on_message(make_message("$remind 5m stretch", channel=channel))
+        assert sent_text(channel) == ["unable to get tag. tag function parameter is None", ""]
+        release.set()
+        await removal
+
+    run(exercise())

--- a/tests/test_bot_runtime.py
+++ b/tests/test_bot_runtime.py
@@ -212,56 +212,29 @@ def test_unreachable_runtime_releases_data_directory_claim(tmp_path: Path) -> No
     assert replacement is not None
 
 
-def test_ready_synchronizes_activation_before_initializing_guilds(tmp_path: Path) -> None:
-    guild = make_guild(101, "Renamed Guild")
-    client = FakeClient(
-        guilds=[guild],
-        private_channels=[SimpleNamespace(id=202, recipient=SimpleNamespace(name="Alice"))],
-    )
-    observed_records: list[dict[str, object]] = []
+@pytest.mark.parametrize("event", ["ready", "join"])
+def test_activation_completes_before_either_guild_module_initializes(tmp_path: Path, event: str) -> None:
+    guild = make_guild(101)
+    observations: list[str] = []
 
     async def tag_factory(_guild: object, path: Path) -> RecordingTag:
-        observed_records.append(json.loads((path.parent / "groups.json").read_text(encoding="utf-8")))
+        assert (path.parent / "groups.json").is_file()
+        observations.append("tag")
         return RecordingTag()
 
-    factories = RecordingFactories()
-    dependencies = _RuntimeDependencies(tag_factory=tag_factory, reminder_factory=factories.make_reminder)
-    runtime = BotRuntime(client, command_delimiter="$", data_dir=tmp_path, _dependencies=dependencies)
+    async def reminder_factory(_guild: object, path: Path) -> RecordingReminder:
+        assert (path.parent / "groups.json").is_file()
+        observations.append("reminder")
+        return RecordingReminder()
 
-    run(runtime.on_ready())
-
-    assert observed_records == [
-        {
-            "DM: Alice": {"enabled": True, "id": "202"},
-            "Renamed Guild": {"enabled": True, "id": "101"},
-        }
-    ]
-    assert factories.reminder_calls == [(guild, tmp_path.resolve() / "reminders")]
-
-
-def test_join_preserves_activation_across_rename_before_initialization(tmp_path: Path) -> None:
-    groups_path = tmp_path / "groups.json"
-    groups_path.write_text(json.dumps({"Old Name": {"enabled": False, "id": "303"}}), encoding="utf-8")
-    guild = make_guild(303, "New Name")
-    observed_records: list[dict[str, object]] = []
-
-    async def tag_factory(_guild: object, path: Path) -> RecordingTag:
-        observed_records.append(json.loads((path.parent / "groups.json").read_text(encoding="utf-8")))
-        return RecordingTag()
-
-    factories = RecordingFactories()
     runtime = BotRuntime(
-        FakeClient(),
+        FakeClient(guilds=[guild]),
         command_delimiter="$",
         data_dir=tmp_path,
-        _dependencies=_RuntimeDependencies(tag_factory=tag_factory, reminder_factory=factories.make_reminder),
+        _dependencies=_RuntimeDependencies(tag_factory=tag_factory, reminder_factory=reminder_factory),
     )
-
-    run(runtime.on_guild_join(guild))
-
-    expected = {"New Name": {"enabled": False, "id": "303"}}
-    assert observed_records == [expected]
-    assert json.loads(groups_path.read_text(encoding="utf-8")) == expected
+    run(runtime.on_ready() if event == "ready" else runtime.on_guild_join(guild))
+    assert observations == ["tag", "reminder"]
 
 
 def test_concurrent_duplicate_ready_initializes_each_registry_once(tmp_path: Path) -> None:
@@ -382,6 +355,8 @@ def test_disabled_group_ignores_commands_until_activate(tmp_path: Path) -> None:
     run(runtime.on_message(message))
     message.content = "$ping"
     run(runtime.on_message(message))
+    message.content = "$   "
+    run(runtime.on_message(message))
     message.content = "$deactive"
     run(runtime.on_message(message))
     message.content = "$activate"
@@ -401,21 +376,6 @@ def test_both_deactivation_aliases_disable_the_group(tmp_path: Path, command: st
     run(runtime.on_message(make_message("$ping", channel=channel)))
 
     assert sent_text(channel) == ["Guild has been deactived."]
-
-
-def test_non_admin_cannot_change_guild_activation(tmp_path: Path) -> None:
-    runtime, _client, _factories = make_runtime(tmp_path)
-    channel = RecordingChannel()
-    author = SimpleNamespace(
-        id=123,
-        name="Alice",
-        bot=False,
-        guild_permissions=SimpleNamespace(administrator=False, manage_guild=False),
-    )
-
-    run(runtime.on_message(make_message("$deactive", channel=channel, author=author)))
-
-    assert sent_text(channel) == ["Only server admins can activate or deactive this bot."]
 
 
 def test_unknown_command_is_logged_without_a_response(
@@ -578,9 +538,7 @@ def test_runtime_uses_owned_groups_path_even_when_environment_points_elsewhere(
 
     run(runtime.on_message(make_message("$deactive")))
 
-    assert json.loads((owned_dir / "groups.json").read_text(encoding="utf-8")) == {
-        "Guild": {"enabled": False, "id": "456"}
-    }
+    assert (owned_dir / "groups.json").is_file()
     assert not (environment_dir / "groups.json").exists()
 
 

--- a/tests/test_bot_state.py
+++ b/tests/test_bot_state.py
@@ -1,4 +1,4 @@
-"""Tests for bot activation persistence helpers."""
+"""Group activation interface and data-directory configuration tests."""
 
 from __future__ import annotations
 
@@ -7,116 +7,283 @@ import json
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
-from bot_state import (
-    DATA_DIR_ENV_VAR,
-    DEFAULT_DATA_DIR,
-    get_state_paths,
-    is_message_group_enabled,
-    set_message_group_enabled,
-    sync_group_records,
-)
+import pytest
+
+from bot_state import DATA_DIR_ENV_VAR, DEFAULT_DATA_DIR, GroupActivation, get_state_paths
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from pathlib import Path
-
-    import pytest
 
 
 def run[T](coro: Coroutine[object, object, T]) -> T:
     return asyncio.run(coro)
 
 
-def test_sync_group_records_creates_groups_file_with_enabled_defaults(tmp_path: Path) -> None:
-    groups_path = tmp_path / "groups.json"
-    guilds = [SimpleNamespace(id=101, name="Guild One"), SimpleNamespace(id=202, name="Guild Two")]
-    private_channels = [
-        SimpleNamespace(id=303, recipient=SimpleNamespace(name="Alice")),
-        SimpleNamespace(id=404, name="Group Chat"),
-    ]
-
-    run(sync_group_records(guilds, private_channels, groups_path))
-
-    assert json.loads(groups_path.read_text(encoding="utf-8")) == {
-        "DM: Alice": {"enabled": True, "id": "303"},
-        "DM: Group Chat": {"enabled": True, "id": "404"},
-        "Guild One": {"enabled": True, "id": "101"},
-        "Guild Two": {"enabled": True, "id": "202"},
-    }
-
-
-def test_sync_group_records_preserves_enabled_values_and_updates_renamed_groups(tmp_path: Path) -> None:
-    groups_path = tmp_path / "groups.json"
-    groups_path.write_text(
-        json.dumps(
-            {
-                "Old Guild Name": {"enabled": False, "id": "101"},
-                "DM: Old Alice": {"enabled": False, "id": "303"},
-                "Manual Server": {"enabled": True, "id": "999"},
-            }
+def message(
+    *, guild_id: int | None = 101, name: str = "Guild", administrator: bool = True, manage_guild: bool = False
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        author=SimpleNamespace(
+            guild_permissions=SimpleNamespace(administrator=administrator, manage_guild=manage_guild)
         ),
-        encoding="utf-8",
+        guild=SimpleNamespace(id=guild_id, name=name) if guild_id is not None else None,
+        channel=SimpleNamespace(id=303, recipient=SimpleNamespace(name="Alice")),
     )
 
+
+def records(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_synchronize_creates_exact_defaults_and_private_names(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "groups.json"
+    activation = GroupActivation(path)
     run(
-        sync_group_records(
-            [SimpleNamespace(id=101, name="New Guild Name")],
-            [SimpleNamespace(id=303, recipient=SimpleNamespace(name="Alice"))],
-            groups_path,
+        activation.synchronize(
+            [SimpleNamespace(id=101, name="Guild One"), SimpleNamespace(id=202, name="Guild Two")],
+            [
+                SimpleNamespace(id=303, recipient=SimpleNamespace(name="Alice")),
+                SimpleNamespace(id=404, name="Group Chat"),
+                SimpleNamespace(id=505, recipients=[SimpleNamespace(name="Bob"), SimpleNamespace(name="Carol")]),
+                SimpleNamespace(id=606),
+            ],
         )
     )
-
-    assert json.loads(groups_path.read_text(encoding="utf-8")) == {
-        "DM: Alice": {"enabled": False, "id": "303"},
-        "Manual Server": {"enabled": True, "id": "999"},
-        "New Guild Name": {"enabled": False, "id": "101"},
+    assert records(path) == {
+        "Guild One": {"enabled": True, "id": "101"},
+        "Guild Two": {"enabled": True, "id": "202"},
+        "DM: Alice": {"enabled": True, "id": "303"},
+        "DM: Group Chat": {"enabled": True, "id": "404"},
+        "DM: Bob, Carol": {"enabled": True, "id": "505"},
+        "DM: 606": {"enabled": True, "id": "606"},
     }
+
+
+def test_synchronize_preserves_renamed_and_invisible_groups(tmp_path: Path) -> None:
+    path = tmp_path / "groups.json"
+    activation = GroupActivation(path)
+    run(activation.set_enabled(message(name="Old Guild"), enabled=False))
+    run(activation.set_enabled(message(guild_id=None), enabled=False))
+    run(activation.record_join(SimpleNamespace(id=999, name="Invisible")))
+    run(
+        activation.synchronize(
+            [SimpleNamespace(id=101, name="New Guild")],
+            [SimpleNamespace(id=303, recipient=SimpleNamespace(name="New Alice"))],
+        )
+    )
+    assert records(path) == {
+        "New Guild": {"enabled": False, "id": "101"},
+        "DM: New Alice": {"enabled": False, "id": "303"},
+        "Invisible": {"enabled": True, "id": "999"},
+    }
+
+
+def test_duplicate_names_stay_distinct_across_rename(tmp_path: Path) -> None:
+    path = tmp_path / "groups.json"
+    activation = GroupActivation(path)
+    run(activation.set_enabled(message(name="Same"), enabled=False))
+    run(activation.synchronize([SimpleNamespace(id=202, name="Same")], []))
+    assert records(path) == {"Same": {"enabled": False, "id": "101"}, "Same (202)": {"enabled": True, "id": "202"}}
+    run(activation.record_join(SimpleNamespace(id=202, name="New")))
+    assert records(path) == {"Same": {"enabled": False, "id": "101"}, "New": {"enabled": True, "id": "202"}}
+
+
+def test_synchronize_empty_creates_file_and_unchanged_operations_do_not_write(tmp_path: Path) -> None:
+    path = tmp_path / "groups.json"
+    activation = GroupActivation(path)
+    run(activation.synchronize([], []))
+    assert records(path) == {}
+    before = path.stat()
+    run(activation.synchronize([], []))
+    assert path.stat() == before
+    guild = SimpleNamespace(id=101, name="Guild")
+    run(activation.record_join(guild))
+    before = path.stat()
+    run(activation.record_join(guild))
+    run(activation.synchronize([guild], []))
+    assert run(activation.is_enabled(message())) is True
+    assert path.stat() == before
+
+
+def test_record_join_preserves_disabled_state_across_rename(tmp_path: Path) -> None:
+    path = tmp_path / "groups.json"
+    activation = GroupActivation(path)
+    run(activation.set_enabled(message(), enabled=False))
+    run(activation.record_join(SimpleNamespace(id=101, name="Renamed")))
+    assert records(path) == {"Renamed": {"enabled": False, "id": "101"}}
+    before = path.stat()
+    run(activation.record_join(SimpleNamespace(id=101, name="Renamed")))
+    assert path.stat() == before
+
+
+@pytest.mark.parametrize(("guild_id", "name"), [(101, "Guild"), (None, "DM: Alice")])
+def test_enabled_check_creates_and_persists_default(tmp_path: Path, guild_id: int | None, name: str) -> None:
+    path = tmp_path / "groups.json"
+    assert run(GroupActivation(path).is_enabled(message(guild_id=guild_id))) is True
+    assert records(path) == {name: {"enabled": True, "id": str(guild_id or 303)}}
+
+
+@pytest.mark.parametrize(("administrator", "manage_guild"), [(True, False), (False, True), (True, True)])
+def test_guild_permissions_allow_activation_changes(tmp_path: Path, *, administrator: bool, manage_guild: bool) -> None:
+    path = tmp_path / "groups.json"
+    activation = GroupActivation(path)
+    context = message(administrator=administrator, manage_guild=manage_guild)
+    assert run(activation.set_enabled(context, enabled=False)) == "Guild has been deactived."
+    assert records(path) == {"Guild": {"enabled": False, "id": "101"}}
+    assert run(activation.is_enabled(context)) is False
+    assert run(activation.set_enabled(context, enabled=True)) == "Guild has been activated."
+    assert records(path) == {"Guild": {"enabled": True, "id": "101"}}
+
+
+@pytest.mark.parametrize("has_permissions", [False, True])
+def test_guild_permission_rejection_does_not_read_or_write(tmp_path: Path, *, has_permissions: bool) -> None:
+    path = tmp_path / "groups.json"
+    activation = GroupActivation(path)
+    context = message(administrator=False)
+    if not has_permissions:
+        context.author = object()
+    assert (
+        run(activation.set_enabled(context, enabled=False)) == "Only server admins can activate or deactive this bot."
+    )
+    assert not path.exists()
+    path.write_text("malformed", encoding="utf-8")
+    assert run(activation.set_enabled(context, enabled=True)) == "Only server admins can activate or deactive this bot."
+    assert path.read_text(encoding="utf-8") == "malformed"
+
+
+def test_private_conversations_allow_activation_changes(tmp_path: Path) -> None:
+    path = tmp_path / "groups.json"
+    activation = GroupActivation(path)
+    context = message(guild_id=None, administrator=False)
+    assert run(activation.set_enabled(context, enabled=False)) == "DM: Alice has been deactived."
+    assert run(activation.is_enabled(context)) is False
+    assert records(path) == {"DM: Alice": {"enabled": False, "id": "303"}}
+
+
+def test_explicit_path_ignores_environment_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "owned" / "groups.json"
+    activation = GroupActivation(path)
+    monkeypatch.setenv(DATA_DIR_ENV_VAR, str(tmp_path / "elsewhere"))
+    run(activation.synchronize([], []))
+    run(activation.record_join(SimpleNamespace(id=101, name="Guild")))
+    run(activation.set_enabled(message(), enabled=False))
+    assert run(activation.is_enabled(message())) is False
+    assert records(path) == {"Guild": {"enabled": False, "id": "101"}}
+    assert not (tmp_path / "elsewhere").exists()
+
+
+def test_normalization_keeps_current_json_rules(tmp_path: Path) -> None:
+    path = tmp_path / "groups.json"
+    path.write_text(
+        json.dumps({"Guild": {"id": 101}, "Disabled": {"id": 202, "enabled": 0, "extra": "ignored"}}), encoding="utf-8"
+    )
+    activation = GroupActivation(path)
+    run(activation.synchronize([SimpleNamespace(id=101, name="Guild"), SimpleNamespace(id=202, name="Disabled")], []))
+    assert records(path) == {"Guild": {"id": "101", "enabled": True}, "Disabled": {"id": "202", "enabled": False}}
+
+
+def test_concurrent_transactions_preserve_all_records_and_activation(tmp_path: Path) -> None:
+    path = tmp_path / "groups.json"
+
+    async def exercise() -> None:
+        activation = GroupActivation(path)
+        await asyncio.gather(
+            *(
+                activation.set_enabled(message(guild_id=index, name=f"Guild {index}"), enabled=False)
+                for index in range(20)
+            )
+        )
+        await asyncio.gather(
+            activation.synchronize([SimpleNamespace(id=index, name=f"Renamed {index}") for index in range(20)], []),
+            activation.record_join(SimpleNamespace(id=99, name="Joined")),
+            activation.is_enabled(message(guild_id=None)),
+        )
+
+    run(exercise())
+    assert records(path) == {
+        **{f"Renamed {index}": {"id": str(index), "enabled": False} for index in range(20)},
+        "Joined": {"id": "99", "enabled": True},
+        "DM: Alice": {"id": "303", "enabled": True},
+    }
+
+
+@pytest.mark.parametrize("operation", ["synchronize", "record_join", "is_enabled", "set_enabled"])
+@pytest.mark.parametrize(("source", "error"), [("{bad json", json.JSONDecodeError), ("[]", TypeError)])
+def test_invalid_file_errors_propagate_unchanged(
+    tmp_path: Path, operation: str, source: str, error: type[Exception]
+) -> None:
+    path = tmp_path / "groups.json"
+    path.write_text(source, encoding="utf-8")
+    activation = GroupActivation(path)
+    if operation == "synchronize":
+        pending = activation.synchronize([], [])
+    elif operation == "record_join":
+        pending = activation.record_join(SimpleNamespace(id=101, name="Guild"))
+    elif operation == "is_enabled":
+        pending = activation.is_enabled(message())
+    else:
+        pending = activation.set_enabled(message(), enabled=False)
+    with pytest.raises(error):
+        run(pending)
+    assert path.read_text(encoding="utf-8") == source
+
+
+def test_filesystem_failure_propagates(tmp_path: Path) -> None:
+    path = tmp_path / "not-a-directory"
+    path.write_text("untouched", encoding="utf-8")
+    with pytest.raises(FileExistsError):
+        run(GroupActivation(path / "groups.json").synchronize([], []))
+    assert path.read_text(encoding="utf-8") == "untouched"
+
+
+def test_cancelled_operation_preserves_file_and_future_operations(tmp_path: Path) -> None:
+    path = tmp_path / "groups.json"
+
+    async def exercise() -> None:
+        activation = GroupActivation(path)
+        await activation.set_enabled(message(), enabled=False)
+        before = path.read_bytes()
+        task = asyncio.create_task(activation.set_enabled(message(), enabled=True))
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert path.read_bytes() == before
+        assert await activation.is_enabled(message()) is False
+        assert await activation.set_enabled(message(), enabled=True) == "Guild has been activated."
+
+    run(exercise())
 
 
 def test_get_state_paths_defaults_to_repo_data_directory(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(DATA_DIR_ENV_VAR, raising=False)
-
     assert get_state_paths() == (DEFAULT_DATA_DIR / "tags", DEFAULT_DATA_DIR / "reminders")
 
 
 def test_get_state_paths_uses_configured_data_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(DATA_DIR_ENV_VAR, str(tmp_path))
-
     assert get_state_paths() == (tmp_path / "tags", tmp_path / "reminders")
 
 
-def test_group_helpers_accept_an_explicit_groups_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    explicit_path = tmp_path / "owned" / "groups.json"
-    environment_path = tmp_path / "environment"
-    monkeypatch.setenv(DATA_DIR_ENV_VAR, str(environment_path))
-    message = SimpleNamespace(
-        author=SimpleNamespace(guild_permissions=SimpleNamespace(administrator=True)),
-        guild=SimpleNamespace(id=101, name="Guild"),
-        channel=SimpleNamespace(id=202),
-    )
+def test_cancellation_during_synchronization_discards_partial_changes(tmp_path: Path) -> None:
+    class CancellingGuild:
+        id = 202
 
-    assert run(is_message_group_enabled(message, explicit_path)) is True
-    assert run(set_message_group_enabled(message, enabled=False, groups_path=explicit_path)) == (
-        "Guild has been deactived."
-    )
-    assert run(is_message_group_enabled(message, explicit_path)) is False
-    assert explicit_path.exists()
-    assert not (environment_path / "groups.json").exists()
+        @property
+        def name(self) -> str:
+            raise asyncio.CancelledError
 
+    async def exercise() -> None:
+        path = tmp_path / "groups.json"
+        activation = GroupActivation(path)
+        await activation.set_enabled(message(), enabled=False)
+        before = path.read_bytes()
+        guilds = [SimpleNamespace(id=101, name="Renamed"), CancellingGuild()]
+        with pytest.raises(asyncio.CancelledError):
+            await activation.synchronize(guilds, [])
+        assert path.read_bytes() == before
+        assert await activation.is_enabled(message()) is False
+        await activation.record_join(SimpleNamespace(id=303, name="Joined"))
+        assert records(path) == {"Guild": {"enabled": False, "id": "101"}, "Joined": {"enabled": True, "id": "303"}}
 
-def test_group_helpers_default_to_the_environment_data_directory(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv(DATA_DIR_ENV_VAR, str(tmp_path))
-    message = SimpleNamespace(
-        author=SimpleNamespace(guild_permissions=SimpleNamespace(administrator=True)),
-        guild=SimpleNamespace(id=303, name="Environment Guild"),
-        channel=SimpleNamespace(id=404),
-    )
-
-    assert run(set_message_group_enabled(message, enabled=False)) == "Environment Guild has been deactived."
-    assert run(is_message_group_enabled(message)) is False
-    assert json.loads((tmp_path / "groups.json").read_text(encoding="utf-8")) == {
-        "Environment Guild": {"enabled": False, "id": "303"}
-    }
+    run(exercise())

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1,47 +1,95 @@
-"""Tests for reminder parsing and creation behavior."""
+"""Reminder behavior through construction, commands, delivery adapters, and shutdown."""
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import discord
 import pytest
+from pydantic import ValidationError
 
 from message_limits import DISCORD_MESSAGE_LIMIT, TRUNCATION_SUFFIX
-from reminders.constants import (
-    DATE_FORMAT,
-    MAX_REMINDER_SECONDS,
-    MAX_REMINDERS_PER_GUILD,
-    REMINDER_DELIVERY_ATTEMPTS,
-    REMINDER_DELIVERY_RETRY_DELAY_SECONDS,
-)
-from reminders.models import ReminderRecord
-from reminders.reminders import Reminders, add_time_to_date, has_datetime_passed, parse_time
+from models import CommandParameters
+from reminders.constants import MAX_REMINDER_SECONDS, MAX_REMINDERS_PER_GUILD
+from reminders.reminders import Reminders, _ReminderDependencies
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from pathlib import Path
+
+NOW = datetime(2026, 6, 4, 12, tzinfo=UTC)
+HELP = (
+    "Format: $remind [amount of time] [message]. Example: $remind 1h check laundry\nSupport units: "
+    "s (seconds), m (minutes), h (hours), or d (days)."
+)
 
 
 def run[T](coro: Coroutine[object, object, T]) -> T:
     return asyncio.run(coro)
 
 
-class RecordingReminders(Reminders):
-    def __init__(self, reminders_json_path: Path) -> None:
-        super().__init__(SimpleNamespace(id=202, name="Guild"), reminders_json_path)
-        self.saved_count = 0
-        self.created_timers: list[tuple[ReminderRecord, float]] = []
+def command(*message: str, author_name: str = "Alice") -> CommandParameters:
+    return CommandParameters(
+        command="remind",
+        message=list(message),
+        created_at=NOW,
+        author_id=1,
+        author_name=author_name,
+        guild_id=202,
+        channel_id=303,
+    )
 
-    async def _save_reminders_unlocked(self) -> None:
-        self.saved_count += 1
 
-    def create_timer(self, reminder: ReminderRecord, delay_seconds: float) -> None:
-        self.created_timers.append((reminder, delay_seconds))
+def record(*, execution_time: str = "2026-06-04T12:05:00") -> dict[str, object]:
+    return {
+        "user_id": 1,
+        "name": "Alice",
+        "message": "check laundry",
+        "created_at": "2026-06-04T12:00:00",
+        "execution_time": execution_time,
+        "timezone": "utc",
+        "guild_id": 202,
+        "channel_id": 303,
+    }
+
+
+def persisted(path: Path) -> dict[str, object]:
+    return json.loads((path / "202.json").read_text(encoding="utf-8"))
+
+
+class ControlledSleep:
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+        self.waiting: asyncio.Queue[asyncio.Future[None]] = asyncio.Queue()
+        self.cancelled = 0
+
+    async def __call__(self, seconds: float) -> None:
+        self.calls.append(seconds)
+        future = asyncio.get_running_loop().create_future()
+        self.waiting.put_nowait(future)
+        try:
+            await future
+        except asyncio.CancelledError:
+            self.cancelled += 1
+            raise
+
+    async def advance(self) -> None:
+        future = await asyncio.wait_for(self.waiting.get(), timeout=1)
+        future.set_result(None)
+        await asyncio.sleep(0)
+
+
+class RecordingChannel(discord.abc.Messageable):
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, dict[str, object]]] = []
+
+    async def send(self, content: str, **kwargs: object) -> None:
+        self.sent.append((content, kwargs))
 
 
 class FakeGuild:
@@ -50,283 +98,303 @@ class FakeGuild:
 
     def __init__(self, channel: object) -> None:
         self.channel = channel
-        self.channel_lookup_count = 0
+        self.lookups: list[int] = []
 
-    def get_channel(self, _channel_id: int) -> object:
-        self.channel_lookup_count += 1
+    def get_channel(self, channel_id: int) -> object:
+        self.lookups.append(channel_id)
         return self.channel
 
 
-class RecordingDeliveryReminders(Reminders):
-    def __init__(self, channel: object, reminders_json_path: Path) -> None:
-        self.fake_guild = FakeGuild(channel)
-        super().__init__(self.fake_guild, reminders_json_path)
-        self.saved_count = 0
+def test_construction_creates_exact_file(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        reminders = await Reminders.create(FakeGuild(None), tmp_path)
+        assert persisted(tmp_path) == {"name": "Guild", "id": 202, "reminders": []}
+        await reminders.close()
+        await reminders.close()
 
-    async def _save_reminders_unlocked(self) -> None:
-        self.saved_count += 1
-
-
-class FlakyMessageable(discord.abc.Messageable):
-    def __init__(self, failures_before_success: int) -> None:
-        self.attempts = 0
-        self.failures_before_success = failures_before_success
-        self.sent_messages: list[str] = []
-        self.sent_kwargs: list[dict[str, object]] = []
-
-    async def send(self, *args: object, **kwargs: object) -> None:
-        self.attempts += 1
-        if self.failures_before_success > 0:
-            self.failures_before_success -= 1
-            response = SimpleNamespace(status=500, reason="Server Error")
-            raise discord.HTTPException(response, "send failed")
-        self.sent_messages.append(str(args[0]))
-        self.sent_kwargs.append(kwargs)
+    run(exercise())
 
 
-def make_reminder() -> ReminderRecord:
-    return ReminderRecord(
-        user_id=1,
-        name="Alice",
-        message="check laundry",
-        created_at=datetime.now(UTC).strftime(DATE_FORMAT),
-        execution_time=(datetime.now(UTC) + timedelta(minutes=5)).strftime(DATE_FORMAT),
-        timezone="utc",
-        guild_id=202,
-        channel_id=303,
-    )
+@pytest.mark.parametrize("message", [(), ("help",), ("list",), ("5m",), ("help", "ignored")])
+def test_help_and_argument_count_quirk(tmp_path: Path, message: tuple[str, ...]) -> None:
+    async def exercise() -> None:
+        reminders = await Reminders.create(FakeGuild(None), tmp_path)
+        before = (tmp_path / "202.json").read_bytes()
+        assert await reminders.handle(command(*message)) == HELP
+        assert (tmp_path / "202.json").read_bytes() == before
+        await reminders.close()
+
+    run(exercise())
 
 
-def patch_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
-    sleep_calls: list[float] = []
+@pytest.mark.parametrize(
+    ("duration", "response"),
+    [
+        ("2w", "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"),
+        ("soon", "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"),
+        ("xs", "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"),
+        (f"{MAX_REMINDER_SECONDS + 1}s", "Why are you using this feature for a reminder that far in the future?"),
+        ("0s", "Why are you trying to set a reminder for the past?"),
+        ("-1h", "Why are you trying to set a reminder for the past?"),
+    ],
+)
+def test_invalid_duration_does_not_write_or_schedule(tmp_path: Path, duration: str, response: str) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        reminders = await Reminders.create(FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(sleep=sleep))
+        before = (tmp_path / "202.json").stat()
+        assert await reminders.handle(command(duration, "stretch")) == response
+        assert (tmp_path / "202.json").stat() == before
+        await asyncio.sleep(0)
+        assert sleep.calls == []
+        await reminders.close()
 
-    async def fake_sleep(seconds: float) -> None:
-        sleep_calls.append(seconds)
-
-    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
-    return sleep_calls
-
-
-def test_parse_time_accepts_supported_units_and_rejects_bad_values() -> None:
-    assert parse_time("30s") == 30
-    assert parse_time("2m") == 120
-    assert parse_time("3h") == 10_800
-    assert parse_time("4d") == 345_600
-    assert parse_time("") is None
-    assert parse_time("10w") is None
-    assert parse_time("soon") is None
-
-
-def test_add_time_and_has_datetime_passed_support_datetime_strings() -> None:
-    start = datetime(2026, 6, 4, 12, 0, 0, tzinfo=UTC)
-    serialized_start = start.strftime(DATE_FORMAT)
-
-    assert add_time_to_date(start, 90) == datetime(2026, 6, 4, 12, 1, 30, tzinfo=UTC)
-    assert add_time_to_date(serialized_start, 90) == datetime(2026, 6, 4, 12, 1, 30, tzinfo=UTC)
-
-    future = (datetime.now(UTC) + timedelta(seconds=60)).strftime(DATE_FORMAT)
-    past = (datetime.now(UTC) - timedelta(seconds=60)).strftime(DATE_FORMAT)
-
-    future_result = has_datetime_passed(future)
-    past_result = has_datetime_passed(past)
-
-    assert future_result.result is False
-    assert 0 < future_result.seconds_until_execution <= 60
-    assert past_result.result is True
-    assert past_result.seconds_until_execution == -1
+    run(exercise())
 
 
-def test_create_reminder_rejects_invalid_durations_without_persisting(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-
-    unsupported = run(reminders.create_reminder("2w", ["stretch"], 1, 202, 303))
-    too_far = run(reminders.create_reminder(f"{MAX_REMINDER_SECONDS + 1}s", ["stretch"], 1, 202, 303))
-    past = run(reminders.create_reminder("0s", ["stretch"], 1, 202, 303))
-
-    assert unsupported == "Unsupported unit of time. Please use s (seconds), m (minutes), h (hours), or d (days)"
-    assert too_far == "Why are you using this feature for a reminder that far in the future?"
-    assert past == "Why are you trying to set a reminder for the past?"
-    assert reminders.saved_count == 0
-    assert reminders.created_timers == []
-    assert reminders.reminders.reminders == []
-
-
-def test_create_reminder_persists_record_and_schedules_timer(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-
-    result = run(reminders.create_reminder("5m", ["check", "laundry"], 1, 202, 303, user_name="Alice"))
-
-    assert result.startswith("Created reminder for Alice to go off at ")
-    assert result.endswith(" that says `check laundry`")
-    assert reminders.saved_count == 1
-    assert len(reminders.reminders.reminders) == 1
-    assert len(reminders.created_timers) == 1
-
-    reminder = reminders.reminders.reminders[0]
-    scheduled_reminder, delay_seconds = reminders.created_timers[0]
-
-    assert scheduled_reminder is reminder
-    assert delay_seconds == 300
-    assert reminder.user_id == 1
-    assert reminder.name == "Alice"
-    assert reminder.message == "check laundry"
-    assert reminder.guild_id == 202
-    assert reminder.channel_id == 303
-
-
-def test_create_reminder_uses_provided_user_name_without_fetching_user(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-
-    result = run(
-        reminders.create_reminder(
-            "5m",
-            ["check", "laundry"],
-            1,
-            202,
-            303,
-            user_name="Alice From Message",
+@pytest.mark.parametrize(("duration", "delay"), [("30s", 30), ("2M", 120), ("3h", 10800), ("4d", 345600)])
+def test_supported_durations_schedule(tmp_path: Path, duration: str, delay: int) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
         )
-    )
+        await reminders.handle(command(duration, "stretch"))
+        await asyncio.sleep(0)
+        assert sleep.calls == [delay]
+        await reminders.close()
 
-    assert result.startswith("Created reminder for Alice From Message to go off at ")
-    assert reminders.reminders.reminders[0].name == "Alice From Message"
-
-
-def test_create_reminder_falls_back_to_user_id_when_name_is_unavailable(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-
-    result = run(reminders.create_reminder("5m", ["check", "laundry"], 1, 202, 303))
-
-    assert result.startswith("Created reminder for 1 to go off at ")
-    assert reminders.reminders.reminders[0].name == "1"
+    run(exercise())
 
 
-def test_create_reminder_truncates_message_and_response_to_discord_limit(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-    long_message = "a" * (DISCORD_MESSAGE_LIMIT + 50)
+@pytest.mark.parametrize("author_name", ["Alice", ""])
+def test_create_persists_before_scheduling_and_formats_dates(tmp_path: Path, author_name: str) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        snapshots: list[dict[str, object]] = []
 
-    result = run(reminders.create_reminder("5m", [long_message], 1, 202, 303, user_name="Alice"))
+        async def observe_sleep(seconds: float) -> None:
+            snapshots.append(persisted(tmp_path))
+            await sleep(seconds)
 
-    assert len(result) == DISCORD_MESSAGE_LIMIT
-    assert result.endswith(TRUNCATION_SUFFIX)
-    assert len(reminders.reminders.reminders[0].message) == DISCORD_MESSAGE_LIMIT
-    assert reminders.reminders.reminders[0].message.endswith(TRUNCATION_SUFFIX)
-
-
-def test_list_reminders_truncates_to_discord_limit(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-    future_execution = (datetime.now(UTC) + timedelta(days=1)).strftime(DATE_FORMAT)
-    for index in range(25):
-        reminders.reminders.reminders.append(
-            ReminderRecord(
-                user_id=index,
-                name=f"User {index}",
-                message="a" * 100,
-                created_at=datetime.now(UTC).strftime(DATE_FORMAT),
-                execution_time=future_execution,
-                timezone="utc",
-                guild_id=202,
-                channel_id=303,
-            )
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=observe_sleep)
         )
-
-    result = run(reminders.list_reminders())
-
-    assert len(result) == DISCORD_MESSAGE_LIMIT
-    assert result.endswith(TRUNCATION_SUFFIX)
-
-
-def test_create_reminder_rejects_new_reminders_when_guild_limit_is_reached(tmp_path: Path) -> None:
-    reminders = RecordingReminders(tmp_path)
-    future_execution = (datetime.now(UTC) + timedelta(days=1)).strftime(DATE_FORMAT)
-    for index in range(MAX_REMINDERS_PER_GUILD):
-        reminders.reminders.reminders.append(
-            ReminderRecord(
-                user_id=index,
-                name=f"User {index}",
-                message="stretch",
-                created_at=datetime.now(UTC).strftime(DATE_FORMAT),
-                execution_time=future_execution,
-                timezone="utc",
-                guild_id=202,
-                channel_id=303,
-            )
+        name = author_name or "1"
+        assert await reminders.handle(command("5m", "check", "laundry", author_name=author_name)) == (
+            f"Created reminder for {name} to go off at 06/04/2026 @ 08:05AM that says `check laundry`"
         )
+        expected = {"name": "Guild", "id": 202, "reminders": [{**record(), "name": name}]}
+        assert persisted(tmp_path) == expected
+        await asyncio.sleep(0)
+        assert snapshots == [expected]
+        assert sleep.calls == [300]
+        assert await reminders.handle(command("list", "ignored")) == (
+            f"\nCreated by: {name}\nReminder date: 06/04/2026 @ 08:05AM\nReminder message: check laundry\n"
+        )
+        await reminders.close()
 
-    result = run(reminders.create_reminder("5m", ["stretch"], 1, 202, 303))
-
-    assert result == (
-        "Reminder limit reached. Delete or wait for a reminder to complete before creating a new one. Limit: "
-        f"{MAX_REMINDERS_PER_GUILD}"
-    )
-    assert reminders.saved_count == 0
-    assert reminders.created_timers == []
-    assert len(reminders.reminders.reminders) == MAX_REMINDERS_PER_GUILD
+    run(exercise())
 
 
-def test_send_message_retries_failures_and_removes_after_success(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_load_cleans_expired_and_schedules_active_records(tmp_path: Path) -> None:
+    source = {"name": "Guild", "id": 202, "reminders": [record(execution_time="2026-06-04T12:00:00"), record()]}
+    (tmp_path / "202.json").write_text(json.dumps(source), encoding="utf-8")
+
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
+        )
+        assert persisted(tmp_path) == {**source, "reminders": [record()]}
+        await asyncio.sleep(0)
+        assert sleep.calls == [300]
+        await reminders.close()
+
+    run(exercise())
+
+
+@pytest.mark.parametrize(
+    ("source", "error"),
+    [("{bad json", json.JSONDecodeError), ('{"id": 202, "name": "Guild", "reminders": [{}]}', ValidationError)],
+)
+def test_malformed_source_unchanged(tmp_path: Path, source: str, error: type[Exception]) -> None:
+    path = tmp_path / "202.json"
+    path.write_text(source, encoding="utf-8")
+    with pytest.raises(error):
+        run(Reminders.create(FakeGuild(None), tmp_path))
+    assert path.read_text(encoding="utf-8") == source
+
+
+def test_list_cleanup_and_empty_response(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        now = NOW
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: now, sleep=ControlledSleep())
+        )
+        assert await reminders.handle(command("list", "ignored")) == "No active reminds were found"
+        await reminders.handle(command("5m", "stretch"))
+        now = datetime(2026, 6, 5, tzinfo=UTC)
+        assert await reminders.handle(command("list", "ignored")) == "No active reminds were found"
+        assert persisted(tmp_path)["reminders"] == []
+        await reminders.close()
+
+    run(exercise())
+
+
+def test_truncation_and_guild_limit(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=ControlledSleep())
+        )
+        result = await reminders.handle(command("5m", "a" * (DISCORD_MESSAGE_LIMIT + 50)))
+        assert len(result) == DISCORD_MESSAGE_LIMIT
+        assert result.endswith(TRUNCATION_SUFFIX)
+        saved = persisted(tmp_path)["reminders"][0]["message"]
+        assert len(saved) == DISCORD_MESSAGE_LIMIT
+        assert saved.endswith(TRUNCATION_SUFFIX)
+        for _ in range(MAX_REMINDERS_PER_GUILD - 1):
+            await reminders.handle(command("5m", "stretch"))
+        before = (tmp_path / "202.json").read_bytes()
+        assert await reminders.handle(command("5m", "stretch")) == (
+            "Reminder limit reached. Delete or wait for a reminder to complete before creating a new one. Limit: 100"
+        )
+        assert (tmp_path / "202.json").read_bytes() == before
+        result = await reminders.handle(command("list", "ignored"))
+        assert len(result) == DISCORD_MESSAGE_LIMIT
+        assert result.endswith(TRUNCATION_SUFFIX)
+        await reminders.close()
+
+    run(exercise())
+
+
+@pytest.mark.parametrize("failures", [0, 2, 3])
+def test_delivery_retries_then_persists_removal(
+    tmp_path: Path, failures: int, caplog: pytest.LogCaptureFixture
 ) -> None:
-    sleep_calls = patch_sleep(monkeypatch)
-    channel = FlakyMessageable(failures_before_success=2)
-    reminders = RecordingDeliveryReminders(channel, tmp_path)
-    reminder = make_reminder()
-    reminders.reminders.reminders.append(reminder)
+    caplog.set_level(logging.INFO, logger="reminders.reminders")
 
-    run(reminders.send_message(reminder, 0))
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        channel = RecordingChannel()
+        guild = FakeGuild(channel)
+        attempts: list[tuple[object, int, str]] = []
 
-    assert channel.attempts == REMINDER_DELIVERY_ATTEMPTS
-    assert channel.sent_messages == ["<@1> reminder: check laundry"]
-    assert channel.sent_kwargs[0]["allowed_mentions"].to_dict() == {"users": [1], "parse": []}
-    assert reminders.reminders.reminders == []
-    assert reminders.saved_count == 1
-    assert sleep_calls == [0, REMINDER_DELIVERY_RETRY_DELAY_SECONDS, REMINDER_DELIVERY_RETRY_DELAY_SECONDS]
+        async def send(target: discord.abc.Messageable, user_id: int, content: str) -> None:
+            attempts.append((target, user_id, content))
+            if len(attempts) <= failures:
+                raise discord.HTTPException(SimpleNamespace(status=500, reason="Server Error"), "send failed")
 
+        reminders = await Reminders.create(
+            guild, tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep, send_reminder=send)
+        )
+        await reminders.handle(command("5m", "check", "laundry"))
+        for _ in range(min(failures + 1, 3)):
+            await sleep.advance()
+        assert attempts == [(channel, 1, "check laundry")] * min(failures + 1, 3)
+        assert guild.lookups == [303] * len(attempts)
+        assert sleep.calls == [300] + [60] * (len(attempts) - 1)
+        assert persisted(tmp_path)["reminders"] == []
+        before = (tmp_path / "202.json").stat()
+        await reminders.close()
+        assert (tmp_path / "202.json").stat() == before
 
-def test_send_message_removes_reminder_after_final_send_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    sleep_calls = patch_sleep(monkeypatch)
-    channel = FlakyMessageable(failures_before_success=REMINDER_DELIVERY_ATTEMPTS)
-    reminders = RecordingDeliveryReminders(channel, tmp_path)
-    reminder = make_reminder()
-    reminders.reminders.reminders.append(reminder)
-
-    with caplog.at_level(logging.ERROR):
-        run(reminders.send_message(reminder, 0))
-
-    assert channel.attempts == REMINDER_DELIVERY_ATTEMPTS
-    assert reminders.reminders.reminders == []
-    assert reminders.saved_count == 1
-    assert sleep_calls == [0, REMINDER_DELIVERY_RETRY_DELAY_SECONDS, REMINDER_DELIVERY_RETRY_DELAY_SECONDS]
-    assert "failed to send reminder after 3 attempts" in caplog.text
+    run(exercise())
+    assert sum(": saving:" in record.message for record in caplog.records) == 2
+    if failures == 3:
+        assert "failed to send reminder after 3 attempts" in caplog.text
 
 
 @pytest.mark.parametrize("channel", [None, object()])
-def test_send_message_retries_unavailable_channels_then_removes_reminder(
-    channel: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    sleep_calls = patch_sleep(monkeypatch)
-    reminders = RecordingDeliveryReminders(channel, tmp_path)
-    reminder = make_reminder()
-    reminders.reminders.reminders.append(reminder)
-
-    with caplog.at_level(logging.ERROR):
-        run(reminders.send_message(reminder, 0))
-
-    assert reminders.fake_guild.channel_lookup_count == REMINDER_DELIVERY_ATTEMPTS
-    assert reminders.reminders.reminders == []
-    assert reminders.saved_count == 1
-    assert sleep_calls == [0, REMINDER_DELIVERY_RETRY_DELAY_SECONDS, REMINDER_DELIVERY_RETRY_DELAY_SECONDS]
-    assert "failed to send reminder after 3 attempts" in caplog.text
-
-
-def test_close_cancels_pending_timer_tasks(tmp_path: Path) -> None:
-    async def exercise_close() -> tuple[int, int]:
-        reminders = Reminders(SimpleNamespace(id=202, name="Guild"), tmp_path)
-        reminders.create_timer(make_reminder(), 3_600)
-        task_count_before_close = len(reminders._timer_tasks)  # noqa: SLF001
+def test_unavailable_channel_retries_then_removes(tmp_path: Path, channel: object) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        guild = FakeGuild(channel)
+        reminders = await Reminders.create(
+            guild, tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
+        )
+        await reminders.handle(command("5m", "stretch"))
+        for _ in range(3):
+            await sleep.advance()
+        assert guild.lookups == [303, 303, 303]
+        assert sleep.calls == [300, 60, 60]
+        assert persisted(tmp_path)["reminders"] == []
         await reminders.close()
-        return task_count_before_close, len(reminders._timer_tasks)  # noqa: SLF001
 
-    assert run(exercise_close()) == (1, 0)
+    run(exercise())
+
+
+def test_default_sender_preserves_mention_policy(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        channel = RecordingChannel()
+        reminders = await Reminders.create(
+            FakeGuild(channel), tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
+        )
+        await reminders.handle(command("5m", "check", "laundry"))
+        await sleep.advance()
+        content, kwargs = channel.sent[0]
+        assert content == "<@1> reminder: check laundry"
+        assert kwargs["allowed_mentions"].to_dict() == {"users": [1], "parse": []}
+        assert persisted(tmp_path)["reminders"] == []
+        await reminders.close()
+
+    run(exercise())
+
+
+def test_close_awaits_cancellation_and_retains_pending_records(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        guild = FakeGuild(RecordingChannel())
+        reminders = await Reminders.create(
+            guild, tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep)
+        )
+        await reminders.handle(command("5m", "stretch"))
+        await reminders.handle(command("1h", "rest"))
+        await asyncio.sleep(0)
+        before = (tmp_path / "202.json").read_bytes()
+        await reminders.close()
+        assert sleep.cancelled == 2
+        assert guild.lookups == []
+        assert (tmp_path / "202.json").read_bytes() == before
+        await reminders.close()
+
+    run(exercise())
+
+
+def test_cancelled_delivery_does_not_remove_or_retry(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        sleep = ControlledSleep()
+        guild = FakeGuild(RecordingChannel())
+
+        async def send(_channel: discord.abc.Messageable, _user_id: int, _content: str) -> None:
+            raise asyncio.CancelledError
+
+        reminders = await Reminders.create(
+            guild, tmp_path, _dependencies=_ReminderDependencies(now=lambda: NOW, sleep=sleep, send_reminder=send)
+        )
+        await reminders.handle(command("5m", "stretch"))
+        before = (tmp_path / "202.json").read_bytes()
+        await sleep.advance()
+        await reminders.close()
+        assert sleep.calls == [300]
+        assert guild.lookups == [303]
+        assert (tmp_path / "202.json").read_bytes() == before
+
+    run(exercise())
+
+
+def test_command_cancellation_propagates(tmp_path: Path) -> None:
+    def cancelled_now() -> datetime:
+        raise asyncio.CancelledError
+
+    async def exercise() -> None:
+        reminders = await Reminders.create(
+            FakeGuild(None), tmp_path, _dependencies=_ReminderDependencies(now=cancelled_now)
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await reminders.handle(command("5m", "stretch"))
+        assert persisted(tmp_path)["reminders"] == []
+        await reminders.close()
+
+    run(exercise())


### PR DESCRIPTION
## Summary
- Add one runtime-owned `GroupActivation` instance with an explicit path and a private lock across complete file transactions.
- Hide identity normalization, permissions, rename preservation, and persistence behind synchronize, join, enabled-check, and activation-change operations.
- Replace raw helper tests with interface tests and focus runtime tests on ordering, gating, responses, and error propagation.

## Verification
- `uv run ruff format --check`
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest -q` — 131 passed, including reminder integration

## Integration
Depends on #6: merge #6 into `discord` first, then merge this PR. This branch includes the reminder commit so the combined implementation is already tested; both PRs target `discord` to avoid a manual retargeting step. Persisted JSON, defaults, command aliases, permissions, response text, and Vault configuration are unchanged.
